### PR TITLE
fix(fpp-analytics): accept full URL in BEA_BASE_URL

### DIFF
--- a/fpp-analytics/README.md
+++ b/fpp-analytics/README.md
@@ -39,8 +39,8 @@ uv run python update_readmodel.py
 |--------|-------------|
 | `ANALYTICS_SECRET_TOKEN` | Bearer token for API authentication |
 | `FPP_ANALYTICS_SENTRY_DSN` | Sentry DSN (optional) |
-| `BEA_BASE_URL` | Email service base URL (optional) |
-| `BEA_SECRET_KEY` | Email service auth key (optional) |
+| `BEA_BASE_URL` | Email service base URL — full URL with scheme, no trailing slash (e.g. `https://bun-email-api.example.com`). Optional. |
+| `BEA_SECRET_KEY` | Email service bearer token (optional) |
 
 ### Required Secrets for `fpp-analytics-updater`
 

--- a/fpp-analytics/util/http_client.py
+++ b/fpp-analytics/util/http_client.py
@@ -24,7 +24,7 @@ async def send_daily_email(daily_analytics: dict[str, Any]) -> None:
         print("BEA service not configured, skipping email")
         return
 
-    url = f"http://{BEA_BASE_URL}:3010/fpp-daily-analytics"
+    url = f"{BEA_BASE_URL.rstrip('/')}/fpp-daily-analytics"
 
     try:
         async with httpx.AsyncClient() as client:

--- a/fpp-server/src/index.ts
+++ b/fpp-server/src/index.ts
@@ -408,7 +408,7 @@ async function shutdown(signal: string): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
   log.info({ signal }, 'Shutdown initiated, draining for 3s');
-  await new Promise(resolve => setTimeout(resolve, 3000));
+  await new Promise((resolve) => setTimeout(resolve, 3000));
   try {
     await app.stop();
   } catch (error) {

--- a/src/server/api/routers/analytics.router.ts
+++ b/src/server/api/routers/analytics.router.ts
@@ -117,9 +117,12 @@ export const analyticsRouter = createTRPCRouter({
     };
   }),
   getServerAnalytics: publicProcedure.query(async () => {
-    const response = await fetch(`https://${env.NEXT_PUBLIC_FPP_SERVER_URL}/analytics`, {
-      cache: 'no-store',
-    }).catch((error) => {
+    const response = await fetch(
+      `https://${env.NEXT_PUBLIC_FPP_SERVER_URL}/analytics`,
+      {
+        cache: 'no-store',
+      },
+    ).catch((error) => {
       throw toCustomTRPCError(error, 'Failed to fetch server analytics API', {
         component: 'analyticsRouter',
         action: 'getServerAnalytics',


### PR DESCRIPTION
## Summary

After the BEA migration to VPS, `bun-email-api` is publicly reachable at `https://bun-email-api.jkrumm.com` (Cloudflare Tunnel + Traefik on the new VPS). Cloudflare doesn't proxy raw TCP on port 3010 on non-Enterprise plans, so the only way to reach BEA from `fpp-analytics-updater` is via the public HTTPS endpoint.

`fpp-analytics/util/http_client.py` previously hardcoded `http://{BEA_BASE_URL}:3010/...` — a holdover from when BEA and fpp-analytics ran on the same SDS box on a shared Docker network. This PR drops that prefix and lets `BEA_BASE_URL` be a full URL.

The `.env.example` already documented the full-URL format (`BEA_BASE_URL=https://your-backend-url.com`); only the code was the outlier.

## Coordinated cleanup in `jkrumm/vps`

[`vps@9a8afcd`](https://github.com/jkrumm/vps/commit/9a8afcd) drops the now-NXDOMAIN legacy `Host(`fpp-server.${DOMAIN}`)` and `Host(`fpp-analytics.${DOMAIN}`)` arms from the Traefik labels in `apps/fpp/compose.yml`. The labels will land on the new fpp-server / fpp-analytics containers when RollHook redeploys for this PR — one restart, both fixes.

## ⚠️ Merge timing — recommended at night

Merging this redeploys all three FPP services via RollHook (`fpp-server`, `fpp-analytics`, `fpp-analytics-updater`). **`fpp-server` keeps room state in memory** — redeployment resets active rooms. Recommend merging when traffic is low.

## Required before merge — two steps on VPS

```bash
# 1. Pull the vps-side label cleanup so the new containers pick it up
ssh vps "cd ~/vps && git pull --ff-only"

# 2. Set the real BEA_BASE_URL (currently NEEDS_UPDATE_BEFORE_CUTOVER placeholder)
op item edit fpp --vault vps --account tkrumm \
  "BEA_BASE_URL[text]=https://bun-email-api.jkrumm.com"
# BEA_SECRET_KEY is already set (matches op://vps/bun-email-api/SECRET_KEY)
```

Without #2, the new `fpp-analytics-updater` container boots with a placeholder URL and the daily 10:00 analytics email will keep failing.

## Verification after merge

After RollHook redeploys all three containers:
- `fpp-fpp-server-N`, `fpp-fpp-analytics-N`, `fpp-fpp-analytics-updater-N` all boot healthy
- Traefik routers only carry the `server.free-planning-poker.com` / `analytics.free-planning-poker.com` arms (legacy jkrumm.com arms gone)
- New `fpp-analytics-updater` reads real `BEA_BASE_URL` + `BEA_SECRET_KEY` from 1Password
- Tomorrow 10:00 cron POSTs to `https://bun-email-api.jkrumm.com/fpp-daily-analytics`, VPS BEA logs the request, Resend sends to `BEA_RECEIVER_EMAIL`

To trigger the daily email immediately instead of waiting for cron, exec into the running updater:

```bash
ssh vps 'docker exec fpp-fpp-analytics-updater-N python -c "import asyncio; from util.http_client import send_daily_email; asyncio.run(send_daily_email({\"votes\":1,\"estimations\":1,\"rooms\":1,\"unique_users\":1,\"page_views\":1}))"'
```

## Test plan

- [ ] CI passes (lint + typecheck on the touched Python file)
- [ ] After merge: `docker ps` shows three new fpp-fpp-* containers healthy
- [ ] Traefik dashboard shows only the `*.free-planning-poker.com` Host arms on the FPP routers
- [ ] Tomorrow morning: daily-analytics email lands in inbox (or trigger manually as above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified email integration settings: BEA_BASE_URL must be a full URL (include scheme, no trailing slash) and BEA_SECRET_KEY is an optional bearer token for the email service.

* **Improvements**
  * Adjusted how the email service endpoint URL is formed to use the configured base URL directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->