### PR TITLE
refactor: server facade clean rename to recordError — Observability v2 P3

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -23,12 +23,7 @@ import { User } from './room.entity';
 import { roomSnapshot } from './room.snapshot';
 import { RoomState } from './room.state';
 import { type Analytics } from './types';
-import {
-  addBreadcrumb,
-  captureError,
-  captureMessage,
-  recordEvent,
-} from './utils/app-error';
+import { recordError, recordEvent } from './utils/app-error';
 import { instrumentAction } from './utils/instrument-action';
 import { WEBSOCKET_CONSTANTS } from './websocket.constants';
 
@@ -98,7 +93,7 @@ const app = new Elysia({
       return { error: 'Not found', timestamp: Date.now() };
     }
 
-    captureError(
+    recordError(
       error as Error,
       {
         component: 'elysiaOnError',
@@ -166,26 +161,20 @@ app.ws('/ws', {
   }),
   async open(ws) {
     const { roomId, userId, username } = ws.data.query;
-
-    addBreadcrumb('WebSocket connection opened', 'websocket', {
-      roomId: roomId ? String(roomId) : 'unknown',
-      userId: userId ?? 'unknown',
-    });
+    // Connection success is recorded as the ws.connected event below, after
+    // setup; rejections here are operator narration → Pino warnings.
 
     if (!roomId || !userId || !username) {
-      captureMessage(
-        'WebSocket connection missing query parameters',
+      log.warn(
         {
           component: 'websocketOpen',
           action: 'validateParams',
-          extra: {
-            wsId: ws.id,
-            hasRoomId: !!roomId,
-            hasUserId: !!userId,
-            hasUsername: !!username,
-          },
+          wsId: ws.id,
+          hasRoomId: !!roomId,
+          hasUserId: !!userId,
+          hasUsername: !!username,
         },
-        'medium',
+        'WebSocket connection missing query parameters',
       );
       ws.close(1008, 'Missing parameters');
       return;
@@ -194,18 +183,15 @@ app.ws('/ws', {
     // Validate username with shared validation logic (strict mode)
     const usernameValidation = validateUsername(username, { strict: true });
     if (!usernameValidation.isValid) {
-      captureMessage(
-        'WebSocket connection with invalid username',
+      log.warn(
         {
           component: 'websocketOpen',
           action: 'validateUsername',
-          extra: {
-            wsId: ws.id,
-            username: username.slice(0, 20),
-            error: usernameValidation.error ?? 'Unknown validation error',
-          },
+          wsId: ws.id,
+          username: username.slice(0, 20),
+          error: usernameValidation.error ?? 'Unknown validation error',
         },
-        'medium',
+        'WebSocket connection with invalid username',
       );
       ws.close(1008, usernameValidation.error ?? 'Invalid username');
       return;
@@ -245,7 +231,7 @@ app.ws('/ws', {
         [ATTR.USER_ID]: userId,
       });
     } catch (error) {
-      captureError(
+      recordError(
         error as Error,
         {
           component: 'websocketOpen',
@@ -270,14 +256,14 @@ app.ws('/ws', {
         typeof data === 'object'
           ? JSON.stringify(data).slice(0, 200)
           : String(data).slice(0, 200);
-      captureMessage(
-        'Invalid WebSocket message format',
+      log.warn(
         {
           component: 'websocketMessage',
           action: 'validateMessage',
-          extra: { wsId: ws.id, receivedData: safeData },
+          wsId: ws.id,
+          receivedData: safeData,
         },
-        'medium',
+        'Invalid WebSocket message format',
       );
       ws.send(JSON.stringify({ error: 'Invalid message format', wsId: ws.id }));
       return;
@@ -310,6 +296,9 @@ app.ws('/ws', {
     // 1006 = Abnormal closure (no close frame - very common for tab closes, network issues)
     const expectedCloseCodes = [1000, 1001, 1005, 1006];
     if (!expectedCloseCodes.includes(code)) {
+      // Abnormal close → the ws.disconnected event (carries room/user +
+      // close.reason). A Pino debug line keeps the raw reason text for the
+      // terminal without a second OTEL record.
       recordEvent(EVENT.WS_DISCONNECTED, {
         ...(connection && {
           [ATTR.ROOM_ID]: connection.roomId,
@@ -317,28 +306,16 @@ app.ws('/ws', {
         }),
         [ATTR.CLOSE_REASON]: String(code),
       });
-
-      addBreadcrumb('WebSocket abnormal close', 'websocket', {
-        closeCode: String(code),
-        reason: reason?.toString() ?? 'unknown',
-        roomId: connection?.roomId ? String(connection.roomId) : 'unknown',
-        userId: connection?.userId ?? 'unknown',
-      });
-
-      captureMessage(
-        `WebSocket closed with abnormal code: ${code}`,
+      log.debug(
         {
           component: 'websocketClose',
-          action: 'handleClose',
-          extra: {
-            closeCode: code,
-            reason: reason?.toString() ?? 'none',
-            wsId: ws.id,
-            roomId: connection?.roomId ? String(connection.roomId) : 'unknown',
-            userId: connection?.userId ?? 'unknown',
-          },
+          closeCode: code,
+          reason: reason?.toString() ?? 'none',
+          wsId: ws.id,
+          roomId: connection?.roomId ?? null,
+          userId: connection?.userId ?? null,
         },
-        'low',
+        `WebSocket closed with abnormal code: ${code}`,
       );
     }
 

--- a/apps/server/src/message.handler.ts
+++ b/apps/server/src/message.handler.ts
@@ -17,7 +17,7 @@ import {
 } from '@fpp/shared';
 import { User } from './room.entity';
 import { type RoomState } from './room.state';
-import { captureError, captureMessage } from './utils/app-error';
+import { recordError } from './utils/app-error';
 import { WEBSOCKET_CONSTANTS } from './websocket.constants';
 
 export class MessageHandler {
@@ -108,23 +108,20 @@ export class MessageHandler {
       return;
     }
 
-    // If we get here, it's an unknown action
+    // If we get here, it's an unknown action — operator narration, not a domain
+    // event or error; a Pino warning (stdout) is the right signal.
     const unknownAction = (data as { action?: unknown }).action;
-    captureMessage(
-      'Unknown WebSocket action received',
+    log.warn(
       {
         component: 'messageHandler',
         action: 'routeAction',
-        extra: {
-          wsId: ws.id,
-          receivedAction:
-            typeof unknownAction === 'string' ||
-            typeof unknownAction === 'number'
-              ? String(unknownAction)
-              : JSON.stringify(unknownAction),
-        },
+        wsId: ws.id,
+        receivedAction:
+          typeof unknownAction === 'string' || typeof unknownAction === 'number'
+            ? String(unknownAction)
+            : JSON.stringify(unknownAction),
       },
-      'medium',
+      'Unknown WebSocket action received',
     );
     ws.send(
       JSON.stringify({
@@ -245,7 +242,7 @@ export class MessageHandler {
             }),
           );
         } catch (error: unknown) {
-          captureError(
+          recordError(
             error as Error,
             {
               component: 'handleKick',
@@ -263,7 +260,7 @@ export class MessageHandler {
         try {
           kickedUser.ws.close();
         } catch (error: unknown) {
-          captureError(
+          recordError(
             error as Error,
             {
               component: 'handleKick',

--- a/apps/server/src/room.entity.ts
+++ b/apps/server/src/room.entity.ts
@@ -10,7 +10,7 @@ import { validateUsername } from '@fpp/shared';
 import { ATTR, EVENT } from '@fpp/shared/telemetry';
 import { metrics } from './telemetry';
 import { preciseTimeout } from './utils';
-import { captureError, recordEvent } from './utils/app-error';
+import { recordError, recordEvent } from './utils/app-error';
 import { tracedFetch } from './utils/traced-fetch';
 
 // Re-export shared types from room.types for backward compatibility
@@ -262,7 +262,7 @@ export class RoomServer extends RoomBase {
 
     if (!fppServerSecret) {
       const error = new Error('FPP_SERVER_SECRET not set');
-      captureError(
+      recordError(
         error,
         {
           component: 'roomEntity',
@@ -316,7 +316,7 @@ export class RoomServer extends RoomBase {
         // Persistence path for vote + estimation rows. Failure is silent to
         // the user (WebSocket flip already succeeded) but means data loss —
         // surface as warning so it shows in HyperDX.
-        captureError(
+        recordError(
           error as Error,
           {
             component: 'roomEntity',

--- a/apps/server/src/room.snapshot.ts
+++ b/apps/server/src/room.snapshot.ts
@@ -1,6 +1,6 @@
 import { RedisClient } from 'bun';
 import { log } from './index';
-import { captureError, captureMessage } from './utils/app-error';
+import { recordError } from './utils/app-error';
 
 const ROOM_KEY_PREFIX = 'fpp:room:';
 // 6h covers long-idle rooms (open tab through a meeting + lunch). The 30-min
@@ -54,7 +54,7 @@ export class RoomSnapshotStore {
         );
       };
       void this.client.connect().catch((err: Error) => {
-        captureError(
+        recordError(
           err,
           {
             component: 'roomSnapshot',
@@ -65,7 +65,7 @@ export class RoomSnapshotStore {
         );
       });
     } catch (err) {
-      captureError(
+      recordError(
         err as Error,
         { component: 'roomSnapshot', action: 'init' },
         'high',
@@ -109,15 +109,16 @@ export class RoomSnapshotStore {
         ),
       ]);
     } catch (err) {
-      // Fail open: hydration miss is recoverable (room starts empty).
-      captureMessage(
-        'Redis fetch failed — proceeding without snapshot',
+      // Fail open: hydration miss is recoverable (room starts empty). Operator
+      // narration → Pino warning (not an OTEL error/event).
+      log.warn(
         {
           component: 'roomSnapshot',
           action: 'fetch',
-          extra: { roomId, error: (err as Error).message },
+          roomId,
+          error: (err as Error).message,
         },
-        'medium',
+        'Redis fetch failed — proceeding without snapshot',
       );
       return null;
     }
@@ -179,14 +180,14 @@ export class RoomSnapshotStore {
     this.client
       .expire(`${ROOM_KEY_PREFIX}${roomId}`, SNAPSHOT_TTL_SECONDS)
       .catch((err: Error) => {
-        captureMessage(
-          'Redis TTL touch failed',
+        log.info(
           {
             component: 'roomSnapshot',
             action: 'touch',
-            extra: { roomId, error: err.message },
+            roomId,
+            error: err.message,
           },
-          'low',
+          'Redis TTL touch failed',
         );
       });
   }
@@ -205,14 +206,14 @@ export class RoomSnapshotStore {
     const inflight = this.inflightPersists.get(roomId);
     const issueDel = (): void => {
       client.del(`${ROOM_KEY_PREFIX}${roomId}`).catch((err: Error) => {
-        captureMessage(
-          'Redis delete failed',
+        log.info(
           {
             component: 'roomSnapshot',
             action: 'delete',
-            extra: { roomId, error: err.message },
+            roomId,
+            error: err.message,
           },
-          'low',
+          'Redis delete failed',
         );
       });
     };
@@ -234,7 +235,7 @@ export class RoomSnapshotStore {
     try {
       json = serialize();
     } catch (err) {
-      captureError(
+      recordError(
         err as Error,
         {
           component: 'roomSnapshot',
@@ -269,14 +270,14 @@ export class RoomSnapshotStore {
     } catch (err) {
       // Fail open: in-memory state is still authoritative; we just lose
       // restart resilience for this room until the next change.
-      captureMessage(
-        'Redis write failed — snapshot may be stale',
+      log.warn(
         {
           component: 'roomSnapshot',
           action: 'write',
-          extra: { roomId, error: (err as Error).message },
+          roomId,
+          error: (err as Error).message,
         },
-        'medium',
+        'Redis write failed — snapshot may be stale',
       );
     }
   }

--- a/apps/server/src/room.state.ts
+++ b/apps/server/src/room.state.ts
@@ -5,7 +5,7 @@ import { RoomServer, type User } from './room.entity';
 import { roomSnapshot } from './room.snapshot';
 import { metrics } from './telemetry';
 import { type Analytics, type AnalyticsUser } from './types';
-import { captureError, captureMessage, recordEvent } from './utils/app-error';
+import { recordError, recordEvent } from './utils/app-error';
 import { WEBSOCKET_CONSTANTS } from './websocket.constants';
 
 type CloseReason = 'empty' | 'timeout';
@@ -109,7 +109,7 @@ export class RoomState {
         'Rehydrated room from Redis snapshot',
       );
     } catch (err) {
-      captureError(
+      recordError(
         err as Error,
         {
           component: 'roomState',
@@ -142,7 +142,7 @@ export class RoomState {
       // addUserToRoom only runs from the WebSocket open/rejoin paths, where
       // ws is always live. A null here means a programming error — bail
       // rather than crash on user.ws.id below.
-      captureMessage(
+      recordError(
         'addUserToRoom called with ws-less user',
         {
           component: 'roomState',
@@ -315,7 +315,7 @@ export class RoomState {
         }
       } catch (error: unknown) {
         failureCount++;
-        captureError(
+        recordError(
           error as Error,
           {
             component: 'roomState',
@@ -333,7 +333,7 @@ export class RoomState {
 
     // Track if there were excessive failures
     if (failureCount > 0 && failureCount >= room.users.length / 2) {
-      captureMessage(
+      recordError(
         'High WebSocket send failure rate in room',
         {
           component: 'roomState',
@@ -396,7 +396,7 @@ export class RoomState {
           );
         }
       } catch (error: unknown) {
-        captureError(
+        recordError(
           error as Error,
           {
             component: 'roomState',

--- a/apps/server/src/utils/app-error.ts
+++ b/apps/server/src/utils/app-error.ts
@@ -44,10 +44,10 @@ const flattenExtra = (
 };
 
 /**
- * Capture an exception. Records on the active span (if any), emits an OTEL
+ * Record an exception. Records on the active span (if any), emits an OTEL
  * log record correlated by trace_id, and logs to Pino for terminal output.
  */
-export function captureError(
+export function recordError(
   error: Error | string,
   context: ErrorContext = {},
   severity: ErrorSeverity = 'medium',
@@ -68,6 +68,8 @@ export function captureError(
 
   const span = trace.getActiveSpan();
   if (span) {
+    // TODO(otel): migrate to a log-based exception event per OTEP 4430 once the
+    // converting processor is wired into SDK init; recordException is shimmed.
     span.recordException(err);
     span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
     if (context.component)
@@ -93,45 +95,6 @@ export function captureError(
 }
 
 /**
- * Capture a non-exception message. Use for informational or
- * warning-level events that aren't errors.
- */
-export function captureMessage(
-  message: string,
-  context: ErrorContext = {},
-  severity: ErrorSeverity = 'medium',
-): void {
-  const logData = {
-    component: context.component ?? 'unknown',
-    action: context.action ?? 'unknown',
-    severity,
-    ...context.extra,
-  };
-  if (severity === 'low') {
-    log.info(
-      logData,
-      `[${severity}] ${context.component}:${context.action} - ${message}`,
-    );
-  } else {
-    log.warn(
-      logData,
-      `[${severity}] ${context.component}:${context.action} - ${message}`,
-    );
-  }
-  otelLogger.emit({
-    severityNumber: SEVERITY_NUMBER[severity],
-    severityText: SEVERITY_TEXT[severity],
-    body: message,
-    attributes: {
-      'fpp.severity': severity,
-      ...(context.component && { 'fpp.component': context.component }),
-      ...(context.action && { 'fpp.action': context.action }),
-      ...flattenExtra(context.extra),
-    },
-  });
-}
-
-/**
  * Record a domain event as an OTEL log-based event: an INFO log record carrying
  * `event.name` plus typed, registry-keyed attributes, correlated to the active
  * trace. This is the §3 "log-based Event" signal — discrete, named occurrences
@@ -146,26 +109,5 @@ export function recordEvent(
     severityNumber: SeverityNumber.INFO,
     severityText: 'INFO',
     attributes: { 'event.name': name, ...attributes },
-  });
-}
-
-/**
- * Breadcrumb-equivalent: emit an INFO log record correlated to the active
- * trace. Query in HyperDX by trace_id to reconstruct the event timeline.
- */
-export function addBreadcrumb(
-  message: string,
-  category = 'user',
-  data?: Record<string, string | number | boolean | null>,
-): void {
-  otelLogger.emit({
-    severityNumber: SeverityNumber.INFO,
-    severityText: 'INFO',
-    body: message,
-    attributes: {
-      'fpp.breadcrumb': 'true',
-      'fpp.category': category,
-      ...flattenExtra(data),
-    },
   });
 }

--- a/apps/server/src/utils/instrument-action.ts
+++ b/apps/server/src/utils/instrument-action.ts
@@ -7,7 +7,7 @@ import {
 import { type ElysiaWS } from 'elysia/ws';
 import { ATTR } from '@fpp/shared/telemetry';
 import { metrics } from '../telemetry';
-import { captureError } from './app-error';
+import { recordError } from './app-error';
 
 // Structural action shape (not the Action union): every action carries these,
 // and SetPresenceAction lacks _traceparent, so a structural optional keeps the
@@ -65,7 +65,7 @@ export function instrumentAction(
         });
       } catch (err) {
         span.setStatus({ code: SpanStatusCode.ERROR });
-        captureError(
+        recordError(
           err as Error,
           { component: 'messageHandler', action: action.action },
           'high',


### PR DESCRIPTION
## Observability v2 — Phase 3 (server)

Clean break of the server facade from the Sentry-shaped trio to the OTEL-native verbs. No deprecated aliases — telemetry was just migrated, so nothing depends on the old names. (Web is P4; the two facades are separate files.)

### Facade (`apps/server/src/utils/app-error.ts`)
- `captureError` → **`recordError`** (unchanged behaviour: span exception + correlated OTEL log + Pino). Added a `// TODO(otel)` note on the `span.recordException` shim per OTEP 4430.
- **Deleted** `captureMessage` and `addBreadcrumb`.

### Call-site migration (all server files)
- `captureError` → `recordError` everywhere.
- **Operator-narration `captureMessage`** (invalid/unknown WS message, connection rejections, Redis fail-open warnings) → Pino `log.warn`/`log.info` on stdout. The OTEL log channel is now reserved for **errors** (`recordError`) and **domain events** (`recordEvent`) — signal discipline per spec §3.
- The two **high-severity bug-guard** `captureMessage`s (ws-less user, >50% broadcast failure) → `recordError`.
- **Redundant lifecycle breadcrumbs/messages dropped** — P2's `ws.connected` / `ws.disconnected` events supersede the "connection opened" / "abnormal close" breadcrumbs.

### Verification
`bun run validate:server` green (format/lint/typecheck/build). No `captureError`/`captureMessage`/`addBreadcrumb` references remain in `apps/server`. Mechanical rename + log-channel reassignment only — the event/metric signals are unchanged from P2 (verified at runtime there).

### Next
P4: web facade (`captureError`→`recordError`, delete `captureMessage`/`addBreadcrumb`, `fpp.userId`→`user.id` userContext renames, client-only `ws.reconnected`).