### PR TITLE
feat: web facade clean rename + client-only events — Observability v2 P4

### DIFF
--- a/apps/web/src/components/index/form.tsx
+++ b/apps/web/src/components/index/form.tsx
@@ -12,7 +12,7 @@ import { IconArrowBadgeRightFilled } from '@tabler/icons-react';
 import { motion, useSpring, useTransform } from 'framer-motion';
 
 import { api } from 'fpp/utils/api';
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 import { generateRoomNumber } from 'fpp/utils/room-number.util';
 
 import { useLocalstorageStore } from 'fpp/store/local-storage.store';
@@ -45,7 +45,7 @@ const IndexForm = () => {
 
       setTimeout(checkReady, 0);
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to initialize IndexForm'),
@@ -71,7 +71,7 @@ const IndexForm = () => {
   if (getOpenRoomNumberQuery.isSuccess && getOpenRoomNumberQuery.data) {
     openRoomNumber = getOpenRoomNumberQuery.data;
   } else if (getOpenRoomNumberQuery.isError) {
-    captureError(
+    recordError(
       getOpenRoomNumberQuery.error || 'Failed to get open room number',
       {
         component: 'IndexForm',
@@ -94,29 +94,21 @@ const IndexForm = () => {
         if (!roomName || roomName === 'null' || roomName === 'undefined') {
           setRoomReadable(null);
         } else {
-          addBreadcrumb('Navigating to existing room', 'navigation', {
-            roomName,
+          router.push(`/room/${roomName}`).catch((error) => {
+            recordError(
+              error instanceof Error ? error : new Error('Navigation failed'),
+              {
+                component: 'IndexForm',
+                action: 'navigateToRoom',
+                extra: { roomName },
+              },
+              'medium',
+            );
           });
-          router
-            .push(`/room/${roomName}`)
-            .then(() => {
-              addBreadcrumb('Navigation to room successful', 'navigation');
-            })
-            .catch((error) => {
-              captureError(
-                error instanceof Error ? error : new Error('Navigation failed'),
-                {
-                  component: 'IndexForm',
-                  action: 'navigateToRoom',
-                  extra: { roomName },
-                },
-                'medium',
-              );
-            });
         }
       });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to handle room navigation'),
@@ -151,7 +143,7 @@ const IndexForm = () => {
         form.setFieldValue('room', roomValue);
       });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to format room input'),
@@ -177,7 +169,7 @@ const IndexForm = () => {
 
   useEffect(() => {
     if (analyticsError) {
-      captureError(
+      recordError(
         analyticsError,
         {
           component: 'IndexForm',
@@ -192,29 +184,21 @@ const IndexForm = () => {
     try {
       setRoomReadable(String(openRoomNumber));
       setRoomEvent(RoomEvent.ENTERED_RANDOM_ROOM);
-      addBreadcrumb('Starting random room', 'navigation', {
-        roomNumber: openRoomNumber,
+      router.push(`/room/${openRoomNumber}`).catch((error) => {
+        recordError(
+          error instanceof Error
+            ? error
+            : new Error('Failed to navigate to random room'),
+          {
+            component: 'IndexForm',
+            action: 'handleStartPlanning',
+            extra: { roomNumber: openRoomNumber },
+          },
+          'medium',
+        );
       });
-      router
-        .push(`/room/${openRoomNumber}`)
-        .then(() => {
-          addBreadcrumb('Navigation to random room successful', 'navigation');
-        })
-        .catch((error) => {
-          captureError(
-            error instanceof Error
-              ? error
-              : new Error('Failed to navigate to random room'),
-            {
-              component: 'IndexForm',
-              action: 'handleStartPlanning',
-              extra: { roomNumber: openRoomNumber },
-            },
-            'medium',
-          );
-        });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to start planning'),
         {
           component: 'IndexForm',
@@ -231,29 +215,21 @@ const IndexForm = () => {
       const roomValue = form.values.room.toLowerCase();
       setRoomReadable(roomValue);
       setRoomEvent(RoomEvent.ENTERED_ROOM_DIRECTLY);
-      addBreadcrumb('Joining specific room', 'navigation', {
-        roomName: roomValue,
+      router.push(`/room/${roomValue}`).catch((error) => {
+        recordError(
+          error instanceof Error
+            ? error
+            : new Error('Failed to navigate to specific room'),
+          {
+            component: 'IndexForm',
+            action: 'handleJoinRoom',
+            extra: { roomName: roomValue },
+          },
+          'medium',
+        );
       });
-      router
-        .push(`/room/${roomValue}`)
-        .then(() => {
-          addBreadcrumb('Navigation to specific room successful', 'navigation');
-        })
-        .catch((error) => {
-          captureError(
-            error instanceof Error
-              ? error
-              : new Error('Failed to navigate to specific room'),
-            {
-              component: 'IndexForm',
-              action: 'handleJoinRoom',
-              extra: { roomName: roomValue },
-            },
-            'medium',
-          );
-        });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to join room'),
         {
           component: 'IndexForm',
@@ -267,7 +243,6 @@ const IndexForm = () => {
 
   useEffect(() => {
     if (hasMounted && isHydrated) {
-      addBreadcrumb('IndexForm fully loaded', 'component', { openRoomNumber });
     }
   }, [hasMounted, isHydrated, openRoomNumber]);
 
@@ -388,7 +363,7 @@ export function AnimatedNumber({
 
       return () => clearTimeout(timeout);
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to animate number'),
         {
           component: 'AnimatedNumber',

--- a/apps/web/src/components/room/error-boundry.tsx
+++ b/apps/web/src/components/room/error-boundry.tsx
@@ -2,7 +2,7 @@ import React, { Component, type ReactNode } from 'react';
 
 import { Button, Container, Text, Title } from '@mantine/core';
 
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 interface Props {
   children: ReactNode;
@@ -27,17 +27,9 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     // Add breadcrumb for error boundary catch
-    addBreadcrumb(
-      `Error boundary caught error in ${this.props.componentName ?? 'Unknown Component'}`,
-      'error',
-      {
-        componentStack: errorInfo.componentStack?.substring(0, 100) ?? 'N/A',
-        errorMessage: error.message,
-      },
-    );
 
     // Capture error with full context
-    captureError(
+    recordError(
       error,
       {
         component: this.props.componentName ?? 'ErrorBoundary',

--- a/apps/web/src/components/room/interactions.tsx
+++ b/apps/web/src/components/room/interactions.tsx
@@ -11,7 +11,7 @@ import { IconCopy, IconEdit, IconEye } from '@tabler/icons-react';
 
 import { fibonacciSequence } from 'fpp/constants/fibonacci.constant';
 
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 import { copyToClipboard } from 'fpp/utils/copy-top-clipboard.util';
 import { isValidMediumint } from 'fpp/utils/number.utils';
 import { executeLeave } from 'fpp/utils/room.util';
@@ -53,7 +53,7 @@ export const Interactions = ({
   const handleCopyUrl = () => {
     try {
       if (!window.location) {
-        captureError(
+        recordError(
           'Window location not available',
           {
             component: 'Interactions',
@@ -65,12 +65,8 @@ export const Interactions = ({
         return;
       }
       copyToClipboard(window.location.toString(), userId);
-      addBreadcrumb('Room URL copied to clipboard', 'room', {
-        roomId,
-        roomName,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to copy room URL'),
         {
           component: 'Interactions',
@@ -85,12 +81,8 @@ export const Interactions = ({
   const handleEditRoomName = () => {
     try {
       setTab(SidebarTabs.settings);
-      addBreadcrumb('Room name edit requested', 'room', {
-        roomId,
-        roomName,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to open room settings'),
@@ -114,12 +106,8 @@ export const Interactions = ({
         isSpectator: !isSpectator,
       });
       setTab(isSpectator ? null : SidebarTabs.spectators);
-      addBreadcrumb('Spectator mode toggled', 'room', {
-        newSpectatorState: !isSpectator,
-        roomId,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to toggle spectator mode'),
@@ -144,12 +132,8 @@ export const Interactions = ({
         roomId,
         userId,
       });
-      addBreadcrumb('Room reset requested', 'room', {
-        roomId,
-        status,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to reset room'),
         {
           component: 'Interactions',
@@ -169,11 +153,8 @@ export const Interactions = ({
         triggerAction,
         router,
       });
-      addBreadcrumb('Room leave requested', 'room', {
-        roomId,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to leave room'),
         {
           component: 'Interactions',
@@ -194,12 +175,8 @@ export const Interactions = ({
         userId,
         estimation: newEstimation,
       });
-      addBreadcrumb('Estimation submitted', 'room', {
-        estimation: newEstimation,
-        roomId,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to submit estimation'),
@@ -219,14 +196,6 @@ export const Interactions = ({
   };
 
   const shouldShowTooltip = userCount === 1 || isHovered;
-
-  addBreadcrumb('Interactions component rendered', 'room', {
-    roomId,
-    isConnected,
-    isSpectator,
-    status,
-    userCount,
-  });
 
   return (
     <div className="fixed bottom-0 left-0 w-screen flex justify-center h-[160px] sm:h-[170px] border-t md:border-0 border-[#424242] bg-[#242424] z-10">

--- a/apps/web/src/components/room/room-wrapper.tsx
+++ b/apps/web/src/components/room/room-wrapper.tsx
@@ -10,11 +10,7 @@ import { notifications } from '@mantine/notifications';
 import { RouteType } from '@fpp/db';
 
 import { api } from 'fpp/utils/api';
-import {
-  addBreadcrumb,
-  captureError,
-  setUserContext,
-} from 'fpp/utils/app-error';
+import { recordError, setUserContext } from 'fpp/utils/app-error';
 import { initializeAudioContext } from 'fpp/utils/room.util';
 import { validateNanoId } from 'fpp/utils/validate-nano-id.util';
 
@@ -54,7 +50,6 @@ const RoomWrapper = () => {
       }
 
       // Reset retry counter on success
-      const hadRetries = retryCountRef.current > 0;
       retryCountRef.current = 0;
 
       setUserIdLocalStorage(userId);
@@ -79,31 +74,13 @@ const RoomWrapper = () => {
         setUserIdLocalStorage,
         setUserIdRoomState,
       });
-
-      addBreadcrumb('Successfully joined room', 'room', {
-        roomId,
-        roomName,
-        userId,
-        retriesNeeded: hadRetries,
-      });
     },
     onError: (error) => {
       const currentRetry = retryCountRef.current;
 
-      addBreadcrumb('joinRoom mutation failed', 'mutation', {
-        retryAttempt: currentRetry,
-        maxRetries,
-        errorMessage: error.message,
-      });
-
       if (currentRetry < maxRetries) {
         const delay = getRetryDelay(currentRetry);
         retryCountRef.current += 1;
-
-        addBreadcrumb('Scheduling joinRoom retry', 'mutation', {
-          nextRetryAttempt: retryCountRef.current,
-          delayMs: delay,
-        });
 
         // Retry after exponential backoff
         retryTimerRef.current = setTimeout(() => {
@@ -114,7 +91,7 @@ const RoomWrapper = () => {
         }, delay);
       } else {
         // Final failure - capture error and show notification
-        captureError(
+        recordError(
           error,
           {
             component: 'RoomWrapper',
@@ -155,8 +132,6 @@ const RoomWrapper = () => {
 
   // Handle invalid username from WebSocket (code 1008)
   const handleInvalidUsername = React.useCallback(() => {
-    addBreadcrumb('Invalid username detected - clearing localStorage', 'auth');
-
     // Clear invalid username from localStorage
     clearUsername();
 
@@ -185,11 +160,9 @@ const RoomWrapper = () => {
       document.documentElement.classList.add('max-h-screen');
       document.documentElement.classList.add('scrollbar-hide');
 
-      addBreadcrumb('Room wrapper mounted', 'component');
-
       // Your existing useEffect logic here...
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to initialize room wrapper'),
@@ -213,7 +186,7 @@ const RoomWrapper = () => {
         document.documentElement.classList.remove('max-h-screen');
         document.documentElement.classList.remove('scrollbar-hide');
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to cleanup room wrapper'),
@@ -240,12 +213,6 @@ const RoomWrapper = () => {
         correctedRoom.length < 3 ||
         correctedRoom.length > 15
       ) {
-        addBreadcrumb('No room specified', 'room', {
-          roomId,
-          roomName,
-          userId,
-        });
-
         willLeave = true;
         setRoomId(null);
         setRoomName(null);
@@ -261,12 +228,6 @@ const RoomWrapper = () => {
       }
 
       if (queryRoom !== correctedRoom) {
-        addBreadcrumb('Needs to correct room URL', 'room', {
-          roomId,
-          roomName,
-          userId,
-        });
-
         willLeave = true;
         setRoomName(correctedRoom);
         setRecentRoom(correctedRoom);

--- a/apps/web/src/components/sidebar/sidebar-room-analytics.tsx
+++ b/apps/web/src/components/sidebar/sidebar-room-analytics.tsx
@@ -1,7 +1,7 @@
 import { RingProgress, Text } from '@mantine/core';
 
 import { api } from 'fpp/utils/api';
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 import { secondsToReadableTime } from 'fpp/utils/number.utils';
 
 import { useLocalstorageStore } from 'fpp/store/local-storage.store';
@@ -54,12 +54,11 @@ const SidebarRoomAnalytics = () => {
   const query = api.room.getRoomStats.useQuery({ roomId });
 
   if (query.isPending) {
-    addBreadcrumb('Loading room analytics', 'analytics', { roomId });
     return null;
   }
 
   if (query.isError) {
-    captureError(
+    recordError(
       query.error || 'Failed to load room analytics',
       {
         component: 'SidebarRoomAnalytics',
@@ -74,7 +73,7 @@ const SidebarRoomAnalytics = () => {
   }
 
   if (!query.data) {
-    captureError(
+    recordError(
       'Room analytics data is null',
       {
         component: 'SidebarRoomAnalytics',
@@ -100,13 +99,6 @@ const SidebarRoomAnalytics = () => {
       spectators,
       spectators_per_vote,
     } = query.data;
-
-    addBreadcrumb('Room analytics loaded successfully', 'analytics', {
-      roomId,
-      votes,
-      estimations,
-      spectators,
-    });
 
     return (
       <SidebarContent
@@ -155,7 +147,7 @@ const SidebarRoomAnalytics = () => {
       />
     );
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to render room analytics'),

--- a/apps/web/src/components/sidebar/sidebar-settings.tsx
+++ b/apps/web/src/components/sidebar/sidebar-settings.tsx
@@ -16,7 +16,7 @@ import { validateUsername } from '@fpp/shared';
 import { IconBell, IconCards, IconVolume } from '@tabler/icons-react';
 
 import { api } from 'fpp/utils/api';
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { useLocalstorageStore } from 'fpp/store/local-storage.store';
 import { useRoomStore } from 'fpp/store/room.store';
@@ -278,12 +278,6 @@ const RoomSettings = ({
         form.setFieldValue('roomName', data.roomName);
         form.setFieldError('roomName', null);
 
-        addBreadcrumb('Room name updated successfully', 'room', {
-          newRoomName: data.roomName,
-          userId,
-          roomId,
-        });
-
         if (userId && roomId && data.roomName) {
           triggerAction({
             action: 'changeRoomName',
@@ -293,7 +287,7 @@ const RoomSettings = ({
           });
         }
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to handle room name update success'),
@@ -307,7 +301,7 @@ const RoomSettings = ({
       }
     },
     onError: (error) => {
-      captureError(
+      recordError(
         error,
         {
           component: 'SidebarSettings',
@@ -370,18 +364,13 @@ const RoomSettings = ({
         .replace(/[^A-Za-z0-9]/g, '')
         .toLowerCase();
 
-      addBreadcrumb('Attempting to update room name', 'room', {
-        oldRoomName: roomName,
-        newRoomName: cleanRoomName,
-      });
-
       updateRoomNameMutation.mutate({
         userId,
         roomId,
         newRoomName: cleanRoomName,
       });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to submit room name update'),

--- a/apps/web/src/components/sidebar/sidebar-spectators.tsx
+++ b/apps/web/src/components/sidebar/sidebar-spectators.tsx
@@ -6,7 +6,7 @@ import type { Action } from '@fpp/shared';
 import { type User } from '@fpp/shared';
 import { IconEye } from '@tabler/icons-react';
 
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { useLocalstorageStore } from 'fpp/store/local-storage.store';
 import { useRoomStore } from 'fpp/store/room.store';
@@ -22,11 +22,6 @@ const SidebarSpectators = ({
   try {
     const users = useRoomStore((store) => store.users);
     const spectators = users.filter((user) => user.isSpectator);
-
-    addBreadcrumb('Spectators sidebar loaded', 'spectators', {
-      spectatorCount: spectators.length,
-      totalUsers: users.length,
-    });
 
     return (
       <SidebarContent
@@ -44,7 +39,7 @@ const SidebarSpectators = ({
       />
     );
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to load spectators sidebar'),
@@ -69,7 +64,6 @@ const SpectatorsList = ({
   // Try/catch used for breadcrumb logging, not JSX error handling
   try {
     if (spectators.length === 0) {
-      addBreadcrumb('No spectators in room', 'spectators');
       return (
         <div className="w-full text-center py-4">
           <Text size="sm" c="dimmed">
@@ -93,7 +87,7 @@ const SpectatorsList = ({
       </div>
     );
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to render spectators list'),
@@ -127,7 +121,7 @@ const SpectatorCard = ({
   const roomId = useLocalstorageStore((state) => state.roomId);
 
   if (!userId || !roomId) {
-    captureError(
+    recordError(
       'Missing required data for spectator card',
       {
         component: 'SpectatorCard',

--- a/apps/web/src/hooks/config-loader.hook.ts
+++ b/apps/web/src/hooks/config-loader.hook.ts
@@ -3,7 +3,7 @@ import { startTransition, useEffect, useState } from 'react';
 import { FeatureFlagType } from '@fpp/db';
 
 import { api } from 'fpp/utils/api';
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { useConfigStore } from 'fpp/store/config.store';
 
@@ -30,7 +30,7 @@ export const useConfigLoader = () => {
 
       setTimeout(checkReady, 0);
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to initialize useConfigLoader'),
@@ -80,9 +80,6 @@ export const useConfigLoader = () => {
       try {
         if (statusGetFeatureFlag === 'success') {
           setFeatureFlags(featureFlags);
-          addBreadcrumb('Feature flags loaded successfully', 'config', {
-            count: featureFlags?.length || 0,
-          });
         } else if (statusGetFeatureFlag === 'error') {
           const fallbackFlags = Object.keys(FeatureFlagType).map((name) => ({
             name: name as keyof typeof FeatureFlagType,
@@ -91,7 +88,7 @@ export const useConfigLoader = () => {
 
           setFeatureFlags(fallbackFlags);
 
-          captureError(
+          recordError(
             featureFlagsError || 'Failed to load feature flags',
             {
               component: 'useConfigLoader',
@@ -103,19 +100,12 @@ export const useConfigLoader = () => {
             },
             'medium',
           );
-
-          addBreadcrumb('Feature flags fallback applied', 'config', {
-            fallbackCount: fallbackFlags.length,
-          });
         }
 
         if (statusGetLatestTag === 'success') {
           setLatestTag(latestTag);
-          addBreadcrumb('Latest tag loaded successfully', 'config', {
-            tag: latestTag || 'none',
-          });
         } else if (statusGetLatestTag === 'error') {
-          captureError(
+          recordError(
             latestTagError || 'Failed to load latest tag',
             {
               component: 'useConfigLoader',
@@ -128,7 +118,7 @@ export const useConfigLoader = () => {
           );
         }
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Unknown error in config loader'),
@@ -158,10 +148,6 @@ export const useConfigLoader = () => {
 
   useEffect(() => {
     if (hasMounted && isHydrated) {
-      addBreadcrumb('Config loader fully initialized', 'component', {
-        featureFlagsStatus: statusGetFeatureFlag,
-        latestTagStatus: statusGetLatestTag,
-      });
     }
   }, [hasMounted, isHydrated, statusGetFeatureFlag, statusGetLatestTag]);
 

--- a/apps/web/src/hooks/use-tracking.hook.ts
+++ b/apps/web/src/hooks/use-tracking.hook.ts
@@ -6,7 +6,7 @@ import { type RouteType } from '@fpp/db';
 
 import { logEndpoint } from 'fpp/constants/logging.constant';
 
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 import { validateNanoId } from 'fpp/utils/validate-nano-id.util';
 
 import { useLocalstorageStore } from 'fpp/store/local-storage.store';
@@ -59,12 +59,6 @@ export const useTrackPageView = (
         window.history.replaceState({}, '', url.toString());
       });
 
-      addBreadcrumb('Page view tracking initiated', 'tracking', {
-        route,
-        roomId: roomId ?? null,
-        hasSource: !!source,
-      });
-
       sendTrackPageView({
         userId,
         route,
@@ -74,7 +68,7 @@ export const useTrackPageView = (
         setUserIdRoomState,
       });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to track page view'),
         {
           component: 'useTrackPageView',
@@ -122,11 +116,6 @@ export const sendTrackPageView = ({
     });
     const url = `${env.NEXT_PUBLIC_API_ROOT}api/track-page-view`;
 
-    addBreadcrumb('Sending page view tracking', 'tracking', {
-      route,
-      hasUserId: !!userId,
-    });
-
     if (navigator.sendBeacon && userId && validateNanoId(userId)) {
       try {
         const blob = new Blob([body], { type: 'application/json' });
@@ -134,9 +123,7 @@ export const sendTrackPageView = ({
         if (!beaconSent) {
           throw new Error('Beacon failed to send');
         }
-        addBreadcrumb('Page view sent via beacon', 'tracking');
       } catch {
-        addBreadcrumb('Beacon failed, falling back to fetch', 'tracking');
         sendViaFetch(url, body, setUserIdLocalStorage, setUserIdRoomState, {
           userId,
           route,
@@ -151,7 +138,7 @@ export const sendTrackPageView = ({
       });
     }
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to send page view tracking'),
@@ -185,9 +172,6 @@ const sendViaFetch = (
     .then((res) => {
       // Handle rate limiting or WAF blocks gracefully - don't capture as errors
       if (res.status === 403 || res.status === 429) {
-        addBreadcrumb('Page view tracking rate limited', 'tracking', {
-          status: res.status,
-        });
         return null;
       }
       if (!res.ok) {
@@ -203,12 +187,9 @@ const sendViaFetch = (
         setUserIdRoomState(data.userId);
         setUserIdLocalStorage(data.userId);
       });
-      addBreadcrumb('Page view tracking successful', 'tracking', {
-        newUserId: data.userId,
-      });
     })
     .catch((fetchError) => {
-      captureError(
+      recordError(
         fetchError instanceof Error
           ? fetchError
           : new Error('Fetch tracking failed'),

--- a/apps/web/src/hooks/useConnectionHealth.ts
+++ b/apps/web/src/hooks/useConnectionHealth.ts
@@ -2,10 +2,11 @@ import { useCallback, useEffect, useRef } from 'react';
 import { ReadyState } from 'react-use-websocket';
 
 import type { HeartbeatAction } from '@fpp/shared';
+import { EVENT } from '@fpp/shared/telemetry';
 
 import { WEBSOCKET_CONSTANTS } from 'fpp/constants/websocket.constants';
 
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError, recordEvent } from 'fpp/utils/app-error';
 
 import { useRoomStore } from 'fpp/store/room.store';
 
@@ -39,10 +40,6 @@ export const useConnectionHealth = ({
 
     if (!wasVisible && isTabVisible.current) {
       // Tab became visible again - reset warnings and check connection
-      addBreadcrumb(
-        'Tab became visible - resetting connection health state',
-        'websocket',
-      );
       warningIssued.current = false;
       recoveryAttempts.current = 0;
 
@@ -69,11 +66,6 @@ export const useConnectionHealth = ({
 
     recoveryAttempts.current++;
     lastRecoveryAttempt.current = now;
-
-    addBreadcrumb('Attempting connection recovery', 'websocket', {
-      attempt: recoveryAttempts.current,
-      maxAttempts: 2, // Reduced to 2 attempts
-    });
 
     // Send heartbeat immediately and one more after 2 seconds
     sendMessage(
@@ -135,13 +127,6 @@ export const useConnectionHealth = ({
               timeSinceLastPong > WEBSOCKET_CONSTANTS.PONG_TIMEOUT_WARNING &&
               !warningIssued.current
             ) {
-              addBreadcrumb('Connection health warning', 'websocket', {
-                timeSinceLastPong,
-                userId,
-                roomId,
-                isTabVisible: isTabVisible.current,
-              });
-
               warningIssued.current = true;
               sendMessage(
                 JSON.stringify({
@@ -173,35 +158,19 @@ export const useConnectionHealth = ({
               // Skip error capture and reload if user is closing the tab
               // This prevents false positives when tab closure causes connection timeout
               if (isUnloadingRef.current) {
-                addBreadcrumb(
-                  'Connection health critical during page unload - skipping',
-                  'websocket',
-                  { timeSinceLastPong },
-                );
                 return;
               }
 
-              addBreadcrumb(
-                'Connection health critical - forcing reload',
-                'websocket',
-                {
-                  timeSinceLastPong,
-                  timeSinceLastReload,
-                  reloadAttempts: reloadAttempts.current,
-                  recoveryAttempts: recoveryAttempts.current,
-                  reason:
-                    recoveryAttempts.current >= 2
-                      ? 'recovery_failed'
-                      : 'timeout_exceeded',
-                },
-              );
+              // The client gave up on the live socket and is force-reloading
+              // itself — a recovery action the authoritative server can't see.
+              recordEvent(EVENT.WS_RECOVERY_RELOAD);
 
               reloadAttempts.current++;
               lastReloadTime.current = Date.now();
               window.location.reload();
             }
           } catch (error) {
-            captureError(
+            recordError(
               error instanceof Error
                 ? error
                 : new Error('Failed to check connection health'),
@@ -223,8 +192,6 @@ export const useConnectionHealth = ({
           checkConnectionHealth,
           WEBSOCKET_CONSTANTS.CONNECTION_HEALTH_CHECK,
         );
-
-        addBreadcrumb('Connection health monitoring started', 'websocket');
       }
 
       // Reset counters when connection is established
@@ -234,7 +201,7 @@ export const useConnectionHealth = ({
         recoveryAttempts.current = 0;
       }
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to initialize connection health monitoring'),
@@ -253,10 +220,9 @@ export const useConnectionHealth = ({
       try {
         if (connectionHealthRef.current) {
           clearInterval(connectionHealthRef.current);
-          addBreadcrumb('Connection health monitoring stopped', 'websocket');
         }
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to cleanup connection health monitoring'),

--- a/apps/web/src/hooks/useHeartbeat.ts
+++ b/apps/web/src/hooks/useHeartbeat.ts
@@ -5,7 +5,7 @@ import { type HeartbeatAction } from '@fpp/shared';
 
 import { WEBSOCKET_CONSTANTS } from 'fpp/constants/websocket.constants';
 
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { useRoomStore } from 'fpp/store/room.store';
 
@@ -34,13 +34,9 @@ export const useHeartbeat = ({
         } satisfies HeartbeatAction);
 
         sendMessage(heartbeatMessage);
-        addBreadcrumb('Manual heartbeat sent', 'websocket', {
-          userId,
-          roomId,
-        });
       }
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to send heartbeat'),
         {
           component: 'useHeartbeat',
@@ -69,7 +65,7 @@ export const useHeartbeat = ({
         }, WEBSOCKET_CONSTANTS.HEARTBEAT_INTERVAL);
       }
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to schedule heartbeat'),
@@ -95,8 +91,6 @@ export const useHeartbeat = ({
         sendHeartbeat();
         // Start the heartbeat schedule
         scheduleNextHeartbeat();
-
-        addBreadcrumb('Heartbeat system started', 'websocket');
       } else {
         // Clear heartbeat when not connected
         if (heartbeatTimeoutRef.current) {
@@ -104,7 +98,7 @@ export const useHeartbeat = ({
         }
       }
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to manage heartbeat system'),
@@ -125,7 +119,7 @@ export const useHeartbeat = ({
           clearTimeout(heartbeatTimeoutRef.current);
         }
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to cleanup heartbeat system'),

--- a/apps/web/src/hooks/usePresenceTracking.ts
+++ b/apps/web/src/hooks/usePresenceTracking.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { type Action } from '@fpp/shared';
 
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { useRoomStore } from 'fpp/store/room.store';
 
@@ -36,12 +36,6 @@ export const usePresenceTracking = ({
 
       // Delay the presence update slightly to avoid race conditions during navigation
       presenceUpdateTimeoutRef.current = setTimeout(() => {
-        addBreadcrumb('Updating user presence', 'presence', {
-          isPresent,
-          userId,
-          roomId,
-        });
-
         triggerAction({
           action: 'setPresence',
           roomId,
@@ -50,7 +44,7 @@ export const usePresenceTracking = ({
         });
       }, 100); // Small delay to let WebSocket connection stabilize
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to update presence'),
         {
           component: 'usePresenceTracking',
@@ -70,10 +64,6 @@ export const usePresenceTracking = ({
     const handleVisibilityChange = () => {
       try {
         const isVisible = !document.hidden;
-        addBreadcrumb('Visibility changed', 'presence', {
-          isVisible,
-          hidden: document.hidden,
-        });
 
         updatePresence(isVisible);
 
@@ -90,7 +80,7 @@ export const usePresenceTracking = ({
               // Reset the pong timer since we're active again
               setLastPongReceived(Date.now());
             } catch (error) {
-              captureError(
+              recordError(
                 error instanceof Error
                   ? error
                   : new Error('Failed to send visibility heartbeat'),
@@ -104,7 +94,7 @@ export const usePresenceTracking = ({
           }, 100);
         }
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to handle visibility change'),
@@ -122,11 +112,10 @@ export const usePresenceTracking = ({
 
     const handleFocus = () => {
       try {
-        addBreadcrumb('Window focused - user is active', 'presence');
         updatePresence(true);
         sendHeartbeat();
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error ? error : new Error('Failed to handle focus'),
           {
             component: 'usePresenceTracking',
@@ -139,10 +128,9 @@ export const usePresenceTracking = ({
 
     const handleBlur = () => {
       try {
-        addBreadcrumb('Window blurred - user is away', 'presence');
         updatePresence(false);
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error ? error : new Error('Failed to handle blur'),
           {
             component: 'usePresenceTracking',
@@ -156,10 +144,9 @@ export const usePresenceTracking = ({
     // Network change detection
     const handleOnline = () => {
       try {
-        addBreadcrumb('Network came online - sending heartbeat', 'presence');
         sendHeartbeat();
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error ? error : new Error('Failed to handle online'),
           {
             component: 'usePresenceTracking',
@@ -180,12 +167,8 @@ export const usePresenceTracking = ({
       window.addEventListener('focus', handleFocus);
       window.addEventListener('blur', handleBlur);
       window.addEventListener('online', handleOnline);
-
-      addBreadcrumb('Presence tracking initialized', 'presence', {
-        isCurrentlyActive,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to initialize presence tracking'),
@@ -216,7 +199,7 @@ export const usePresenceTracking = ({
           clearTimeout(presenceUpdateTimeoutRef.current);
         }
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to cleanup presence tracking'),

--- a/apps/web/src/hooks/useViewMode.ts
+++ b/apps/web/src/hooks/useViewMode.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { useLocalstorageStore } from 'fpp/store/local-storage.store';
 import { useRoomStore } from 'fpp/store/room.store';
@@ -15,13 +15,8 @@ export const useViewMode = () => {
       try {
         const newIsMobile = window.innerWidth < 768;
         setIsMobile(newIsMobile);
-
-        addBreadcrumb('Screen size checked', 'ui', {
-          width: window.innerWidth,
-          isMobile: newIsMobile,
-        });
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to check screen size'),
@@ -37,13 +32,8 @@ export const useViewMode = () => {
     try {
       checkScreenSize();
       window.addEventListener('resize', checkScreenSize);
-
-      addBreadcrumb('View mode initialized', 'ui', {
-        preferCardView,
-        userCount: users.length,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to initialize view mode'),
@@ -59,7 +49,7 @@ export const useViewMode = () => {
       try {
         window.removeEventListener('resize', checkScreenSize);
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to cleanup view mode'),
@@ -80,7 +70,7 @@ export const useViewMode = () => {
 
     return shouldUseCardList ? 'cardList' : 'table';
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to determine view mode'),

--- a/apps/web/src/hooks/useWebSocketRoom.ts
+++ b/apps/web/src/hooks/useWebSocketRoom.ts
@@ -7,13 +7,11 @@ import { env } from 'fpp/env';
 
 import { type Action } from '@fpp/shared';
 import { RoomClient, type RoomDto } from '@fpp/shared';
+import { EVENT } from '@fpp/shared/telemetry';
 import { context, propagation } from '@opentelemetry/api';
 
-import {
-  addBreadcrumb,
-  captureError,
-  captureMessage,
-} from 'fpp/utils/app-error';
+import { recordError, recordEvent } from 'fpp/utils/app-error';
+import { logger } from 'fpp/utils/logger';
 import { executeKick, executeRoomNameChange } from 'fpp/utils/room.util';
 
 import { useRoomStore } from 'fpp/store/room.store';
@@ -104,7 +102,6 @@ export const useWebSocketRoom = ({
 
         if (message.data === 'pong') {
           setLastPongReceived(Date.now());
-          addBreadcrumb('Heartbeat pong received', 'websocket');
           return;
         }
 
@@ -115,31 +112,20 @@ export const useWebSocketRoom = ({
             | { type: 'kicked'; message: string }
             | { type: 'roomNameChanged'; roomName: string };
 
-          addBreadcrumb('WebSocket message received', 'websocket', {
-            type: 'type' in data ? data.type : 'room_update',
-          });
-
           // Handle kick notification
           if ('type' in data && data.type === 'kicked') {
-            addBreadcrumb('User kicked from room', 'room', {
-              reason: data.message,
-            });
             executeKick('kick_notification', router);
             return;
           }
 
           // Handle roomNameChanged notification
           if ('type' in data && data.type === 'roomNameChanged') {
-            addBreadcrumb('Room name changed', 'room', {
-              newName: data.roomName,
-            });
             executeRoomNameChange({ newRoomName: data.roomName, router });
             return;
           }
 
           if ('error' in data) {
             if (data.error === 'User not found - userId not found') {
-              addBreadcrumb('User not found, attempting rejoin', 'websocket');
               if (triggerActionRef.current) {
                 triggerActionRef.current({
                   action: 'rejoin',
@@ -151,7 +137,7 @@ export const useWebSocketRoom = ({
               return;
             }
 
-            captureError(
+            recordError(
               'Server error received',
               {
                 component: 'useWebSocketRoom',
@@ -165,7 +151,7 @@ export const useWebSocketRoom = ({
 
           updateRoomState(RoomClient.fromJson(data));
         } catch (e) {
-          captureError(
+          recordError(
             e instanceof Error
               ? e
               : new Error('Failed to parse WebSocket message'),
@@ -188,11 +174,7 @@ export const useWebSocketRoom = ({
           return;
         }
 
-        addBreadcrumb('WebSocket error occurred', 'websocket', {
-          eventKeys: Object.keys(event).join(', '),
-        });
-
-        captureError(
+        recordError(
           'WebSocket error occurred',
           {
             component: 'useWebSocketRoom',
@@ -208,12 +190,6 @@ export const useWebSocketRoom = ({
       },
 
       onClose: (event) => {
-        addBreadcrumb('WebSocket disconnected', 'websocket', {
-          code: event.code,
-          reason: event.reason || 'No reason provided',
-          wasClean: event.wasClean,
-        });
-
         // Handle code 1008 (policy violation) - usually invalid username
         if (event.code === 1008) {
           const reason = event.reason || '';
@@ -223,16 +199,6 @@ export const useWebSocketRoom = ({
             reason.includes('letters');
 
           if (isUsernameError) {
-            addBreadcrumb(
-              'WebSocket closed: Invalid username detected',
-              'websocket',
-              {
-                code: event.code,
-                reason,
-                message: 'Username validation failed - clearing localStorage',
-              },
-            );
-
             // Notify parent component to clear username and show modal
             if (onInvalidUsername) {
               onInvalidUsername();
@@ -247,47 +213,34 @@ export const useWebSocketRoom = ({
           if (event.code === 1006 || event.code === 1001) {
             // 1006 (abnormal closure) and 1001 (going away) are very common
             // 1001 occurs during CloudFlare proxy restarts - expected behavior
-            addBreadcrumb(
-              'WebSocket closed abnormally (network/timeout/proxy restart)',
-              'websocket',
-              {
-                code: event.code,
-                message:
-                  'Common network disconnection - will reconnect automatically',
-              },
-            );
           } else {
-            // Other unexpected close codes are more concerning
-            captureMessage(
-              'WebSocket closed unexpectedly',
+            // Other unexpected close codes are more concerning. The server
+            // emits the authoritative ws.disconnected event; this is just
+            // client-side operator narration.
+            logger.warn(
               {
                 component: 'useWebSocketRoom',
                 action: 'onClose',
-                extra: {
-                  code: event.code,
-                  reason: event.reason || 'No reason provided',
-                },
+                code: event.code,
+                reason: event.reason || 'No reason provided',
               },
-              'warning',
+              'WebSocket closed unexpectedly',
             );
           }
         }
       },
 
       onOpen: () => {
-        addBreadcrumb('WebSocket connected successfully', 'websocket');
         setConnectedAt();
         setLastPongReceived(Date.now());
       },
 
-      onReconnectStop: (numAttempts) => {
-        // Don't capture as an error - this is expected after 20 retries (~190 seconds)
-        // User likely closed laptop, lost network, or intentionally left
-        addBreadcrumb('WebSocket reconnection exhausted', 'websocket', {
-          attempts: numAttempts,
-          message:
-            'All retry attempts exhausted - expected after prolonged network loss',
-        });
+      onReconnectStop: () => {
+        // Not an error — expected after 20 retries (~190s): laptop closed,
+        // network lost, or the user left. A client-only event the server can't
+        // observe (it never sees the browser give up). user/room come from the
+        // facade's userContext.
+        recordEvent(EVENT.WS_RECONNECT_EXHAUSTED);
       },
     },
   );
@@ -295,9 +248,6 @@ export const useWebSocketRoom = ({
   // Sync readyState to store whenever it changes
   useEffect(() => {
     setReadyState(readyState);
-    addBreadcrumb('WebSocket state changed', 'websocket', {
-      state: ReadyState[readyState],
-    });
   }, [readyState, setReadyState]);
 
   const triggerAction = useCallback(
@@ -306,9 +256,6 @@ export const useWebSocketRoom = ({
         if (readyState === ReadyState.OPEN) {
           const message = serializeWithTraceContext(action);
           sendMessage(message);
-          addBreadcrumb('WebSocket action sent', 'websocket', {
-            action: action.action,
-          });
         } else if (
           readyState === ReadyState.CONNECTING ||
           readyState === ReadyState.CLOSED ||
@@ -327,36 +274,15 @@ export const useWebSocketRoom = ({
             case 'leave':
               // Leave actions are less critical when connection is already down
               // The server will clean up stale connections, and beforeunload uses beacon fallback
-              addBreadcrumb(
-                'Leave action skipped - connection not ready',
-                'websocket',
-                {
-                  readyState: ReadyState[readyState],
-                },
-              );
               return; // Don't queue leave actions
 
             case 'heartbeat':
               // Don't queue heartbeats when not connected - they're only useful when connected
-              addBreadcrumb(
-                'Heartbeat skipped - connection not ready',
-                'websocket',
-                {
-                  readyState: ReadyState[readyState],
-                },
-              );
               return;
 
             case 'rejoin':
               // Rejoin actions are only meaningful when we have a connection attempt
               if (readyState !== ReadyState.CONNECTING) {
-                addBreadcrumb(
-                  'Rejoin action skipped - not connecting',
-                  'websocket',
-                  {
-                    readyState: ReadyState[readyState],
-                  },
-                );
                 return;
               }
               break;
@@ -372,19 +298,9 @@ export const useWebSocketRoom = ({
           };
 
           actionQueueRef.current.push(queuedAction);
-
-          addBreadcrumb(
-            'WebSocket action queued - connection not ready',
-            'websocket',
-            {
-              action: action.action,
-              readyState: ReadyState[readyState],
-              queueLength: actionQueueRef.current.length,
-            },
-          );
         }
       } catch (error) {
-        captureError(
+        recordError(
           error instanceof Error
             ? error
             : new Error('Failed to send WebSocket action'),
@@ -418,11 +334,8 @@ export const useWebSocketRoom = ({
           // stale traceparent captured at queue time.
           const message = serializeWithTraceContext(action);
           sendMessage(message);
-          addBreadcrumb('Queued WebSocket action sent', 'websocket', {
-            action: action.action,
-          });
         } catch (error) {
-          captureError(
+          recordError(
             error instanceof Error
               ? error
               : new Error('Failed to send queued WebSocket action'),
@@ -439,10 +352,9 @@ export const useWebSocketRoom = ({
       });
 
       if (validActions.length > 0) {
-        addBreadcrumb('Processed queued actions', 'websocket', {
-          processedCount: validActions.length,
-          expiredCount: actionQueueRef.current.length - validActions.length,
-        });
+        // Queue drained after the socket came back → the reconnect completed.
+        // Client-only signal (the server just sees fresh actions arrive).
+        recordEvent(EVENT.WS_RECONNECTED);
       }
 
       actionQueueRef.current = [];

--- a/apps/web/src/pages/analytics.tsx
+++ b/apps/web/src/pages/analytics.tsx
@@ -21,7 +21,7 @@ import { RouteType } from '@fpp/db';
 // AG Charts module registration (only needed for analytics page)
 import 'fpp/utils/ag-charts-init';
 import { api } from 'fpp/utils/api';
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { useTrackPageView } from 'fpp/hooks/use-tracking.hook';
 
@@ -76,7 +76,7 @@ function useAnalyticsQuery() {
 
   React.useEffect(() => {
     if (query.error) {
-      captureError(
+      recordError(
         query.error instanceof Error
           ? query.error
           : new Error('Failed to fetch analytics data'),
@@ -104,7 +104,7 @@ function useServerAnalyticsQuery() {
 
   React.useEffect(() => {
     if (query.error) {
-      captureError(
+      recordError(
         query.error instanceof Error
           ? query.error
           : new Error('Failed to fetch server analytics data'),
@@ -246,7 +246,6 @@ const Analytics = () => {
   } = useServerAnalyticsQuery();
 
   const refetch = () => {
-    addBreadcrumb('Analytics manual refresh triggered', 'interaction');
     void refetchAnalytics();
     void refetchServerAnalytics();
   };
@@ -291,24 +290,14 @@ const Analytics = () => {
   // Handle toggle functions with error handling
   const handleHistoricalTableToggle = () => {
     setHistoricalTableOpen(!historicalTableOpen);
-    addBreadcrumb('Historical table view toggled', 'interaction', {
-      newState: !historicalTableOpen,
-    });
   };
 
   const handleReduceReoccurringToggle = () => {
     setReduceReoccurring(!reduceReoccurring);
-    addBreadcrumb('Reoccurring data reduction toggled', 'interaction', {
-      newState: !reduceReoccurring,
-    });
   };
 
   // Initialize tracking
   if (!hasInitialized) {
-    addBreadcrumb('Analytics page initialized', 'page', {
-      hasAnalytics: !!analytics,
-      hasServerAnalytics: !!serverAnalytics,
-    });
     setHasInitialized(true);
   }
 
@@ -330,7 +319,7 @@ const Analytics = () => {
     serverAnalyticsIsError ||
     !serverAnalytics
   ) {
-    captureError(
+    recordError(
       'Critical analytics data missing',
       {
         component: 'Analytics',

--- a/apps/web/src/pages/api/analytics-cron.ts
+++ b/apps/web/src/pages/api/analytics-cron.ts
@@ -7,7 +7,7 @@ import {
 
 import { logEndpoint } from 'fpp/constants/logging.constant';
 
-import { captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 export default async function handler(
   req: NextApiRequest,
@@ -29,8 +29,8 @@ export default async function handler(
     console.log('Daily analytics invoked ', response.status);
     return res.status(200).json({ message: 'Daily analytics invoked' });
   } catch (error) {
-    // captureError already logs to console in development mode
-    captureError(
+    // recordError already logs to console in development mode
+    recordError(
       error instanceof Error
         ? error
         : new Error('Error invoking daily analytics'),

--- a/apps/web/src/pages/api/track-event.ts
+++ b/apps/web/src/pages/api/track-event.ts
@@ -15,7 +15,7 @@ import {
 } from 'fpp/constants/error.constant';
 import HttpStatusCode from 'fpp/constants/http-status-codes.constant';
 
-import { captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 import { findUserById } from 'fpp/utils/db-api.util';
 import { validateNanoId } from 'fpp/utils/validate-nano-id.util';
 
@@ -63,7 +63,7 @@ const TrackEvent = async (req: NextApiRequest, res: NextApiResponse) => {
     }
 
     // System error (5xx) - capture via OTEL
-    captureError(
+    recordError(
       error instanceof Error ? error : new Error('Failed to track event'),
       {
         component: 'track-event',

--- a/apps/web/src/pages/api/track-page-view.ts
+++ b/apps/web/src/pages/api/track-page-view.ts
@@ -14,7 +14,7 @@ import {
   MethodNotAllowedError,
 } from 'fpp/constants/error.constant';
 
-import { captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 import { validateNanoId } from 'fpp/utils/validate-nano-id.util';
 
 import db from 'fpp/server/db/db';
@@ -71,7 +71,7 @@ const TrackPageView = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(200).json({ userId });
   } catch (error) {
     // Capture error with context
-    captureError(
+    recordError(
       error instanceof Error ? error : new Error('Failed to track page view'),
       {
         component: 'track-page-view',
@@ -140,7 +140,7 @@ export const getUserPayload = async (req: NextApiRequest) => {
       geo.city = geoData.city;
     } catch (error) {
       // Geo fetch failure is non-critical, but we should track it
-      captureError(
+      recordError(
         error instanceof Error ? error : new Error('Failed to fetch geo data'),
         {
           component: 'getUserPayload',

--- a/apps/web/src/pages/api/trpc/[trpc].ts
+++ b/apps/web/src/pages/api/trpc/[trpc].ts
@@ -1,7 +1,7 @@
 /**
  * tRPC API Handler for Next.js Pages Router.
  *
- * Errors flow through captureError → OTEL log records correlated by trace_id
+ * Errors flow through recordError → OTEL log records correlated by trace_id
  * with the active tRPC span. See docs/otel-migration/.
  *
  * @see https://trpc.io/docs/v11/server/adapters/nextjs
@@ -11,7 +11,7 @@ import { type NextApiRequest, type NextApiResponse } from 'next';
 import { type TRPCError } from '@trpc/server';
 import { createNextApiHandler } from '@trpc/server/adapters/next';
 
-import { captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 import { logger } from 'fpp/utils/logger';
 
 import { CustomTRPCError } from 'fpp/server/api/custom-error';
@@ -29,7 +29,7 @@ export const config = {
 
 /**
  * tRPC error handler. CustomTRPCError carries metadata (component, action,
- * extra, severity) from routers. captureError records the exception on the
+ * extra, severity) from routers. recordError records the exception on the
  * active span and emits an OTEL log record with the same trace_id.
  */
 const trpcErrorHandler = ({
@@ -43,7 +43,7 @@ const trpcErrorHandler = ({
   path: string | undefined;
   input: unknown;
 }) => {
-  // NOTE: strict monitoring — all errors flow through captureError. Switch to
+  // NOTE: strict monitoring — all errors flow through recordError. Switch to
   // isBusinessLogicError(error) gating once we've validated the classification.
 
   logger.error(
@@ -64,12 +64,12 @@ const trpcErrorHandler = ({
   // Check if error has custom metadata from router
   if (error instanceof CustomTRPCError) {
     // Use metadata provided by router (component, action, extra, severity)
-    captureError(error, error.metadata, error.metadata.severity ?? 'high');
+    recordError(error, error.metadata, error.metadata.severity ?? 'high');
   } else {
     // Fallback for errors without metadata (uncaught system errors)
     const inputObj = input != null && typeof input === 'object' ? input : {};
 
-    captureError(
+    recordError(
       error,
       {
         component: 'trpcMiddleware',

--- a/apps/web/src/pages/contact.tsx
+++ b/apps/web/src/pages/contact.tsx
@@ -18,7 +18,7 @@ import { EventType, FeatureFlagType, RouteType } from '@fpp/db';
 import { IconAlertCircle } from '@tabler/icons-react';
 
 import { api } from 'fpp/utils/api';
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 import { sendTrackEvent } from 'fpp/utils/send-track-event.util';
 
 import { useConfigStore } from 'fpp/store/config.store';
@@ -57,7 +57,7 @@ const Contact: NextPage = () => {
         try {
           return value.trim().length > 50;
         } catch (error) {
-          captureError(
+          recordError(
             error instanceof Error
               ? error
               : new Error('Name validation failed'),
@@ -85,7 +85,7 @@ const Contact: NextPage = () => {
               trimmed.length > 70)
           );
         } catch (error) {
-          captureError(
+          recordError(
             error instanceof Error
               ? error
               : new Error('Email validation failed'),
@@ -104,7 +104,7 @@ const Contact: NextPage = () => {
           const trimmed = value.trim();
           return trimmed.length < 3 || trimmed.length > 100;
         } catch (error) {
-          captureError(
+          recordError(
             error instanceof Error
               ? error
               : new Error('Subject validation failed'),
@@ -122,7 +122,7 @@ const Contact: NextPage = () => {
         try {
           return value.trim().length > 800;
         } catch (error) {
-          captureError(
+          recordError(
             error instanceof Error
               ? error
               : new Error('Message validation failed'),
@@ -141,13 +141,6 @@ const Contact: NextPage = () => {
 
   const handleFormSubmit = () => {
     try {
-      addBreadcrumb('Contact form submission started', 'form', {
-        hasName: !!form.values.name,
-        hasEmail: !!form.values.email,
-        hasSubject: !!form.values.subject,
-        hasMessage: !!form.values.message,
-      });
-
       sendMail.mutate(form.values, {
         onSuccess: () => {
           try {
@@ -157,10 +150,9 @@ const Contact: NextPage = () => {
               message:
                 'Thank you for your message, we will get back to you as soon as possible',
             });
-            addBreadcrumb('Contact form submission successful', 'form');
             form.reset();
           } catch (error) {
-            captureError(
+            recordError(
               error instanceof Error
                 ? error
                 : new Error('Failed to show success notification'),
@@ -174,7 +166,7 @@ const Contact: NextPage = () => {
         },
         onError: (error) => {
           try {
-            captureError(
+            recordError(
               error instanceof Error
                 ? error
                 : new Error('Contact form submission failed'),
@@ -198,7 +190,7 @@ const Contact: NextPage = () => {
               message: 'Something went wrong, please try again later',
             });
           } catch (notificationError) {
-            captureError(
+            recordError(
               notificationError instanceof Error
                 ? notificationError
                 : new Error('Failed to show error notification'),
@@ -219,7 +211,7 @@ const Contact: NextPage = () => {
           userId,
         });
       } catch (trackingError) {
-        captureError(
+        recordError(
           trackingError instanceof Error
             ? trackingError
             : new Error('Failed to track contact form submission'),
@@ -232,7 +224,7 @@ const Contact: NextPage = () => {
         );
       }
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to handle contact form submission'),
@@ -248,16 +240,9 @@ const Contact: NextPage = () => {
   // Track page initialization
   if (!hasInitialized) {
     try {
-      addBreadcrumb('Contact page initialized', 'page', {
-        hasUsername: !!username,
-        hasUserId: !!userId,
-        contactFormEnabled: activeFeatureFlags.includes(
-          FeatureFlagType.CONTACT_FORM,
-        ),
-      });
       setHasInitialized(true);
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to initialize contact page'),

--- a/apps/web/src/pages/roadmap.tsx
+++ b/apps/web/src/pages/roadmap.tsx
@@ -29,7 +29,7 @@ import superjson from 'superjson';
 import { logMsg } from 'fpp/constants/logging.constant';
 
 import { api } from 'fpp/utils/api';
-import { addBreadcrumb, captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { appRouter } from 'fpp/server/api/root';
 import { type Todo } from 'fpp/server/api/routers/roadmap.router';
@@ -58,7 +58,7 @@ export const getStaticProps = async (context: CreateNextContextOptions) => {
     };
   } catch (error) {
     // Log the error but still return props to prevent build failure
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to prefetch roadmap data'),
@@ -68,7 +68,7 @@ export const getStaticProps = async (context: CreateNextContextOptions) => {
       },
       'high',
     );
-    // captureError already logs to console in development mode
+    // recordError already logs to console in development mode
 
     return {
       props: { trpcState: {} },
@@ -95,7 +95,6 @@ const Roadmap = () => {
 
   // Handle loading state
   if (isLoading) {
-    addBreadcrumb('Roadmap data loading', 'page');
     return (
       <>
         <Meta title="Roadmap" />
@@ -115,7 +114,7 @@ const Roadmap = () => {
   if (isError || !roadmap) {
     const errorMessage = error?.message ?? logMsg.SSG_FAILED;
 
-    captureError(
+    recordError(
       error instanceof Error ? error : new Error(errorMessage),
       {
         component: 'Roadmap',
@@ -159,12 +158,6 @@ const Roadmap = () => {
       </>
     );
   }
-
-  addBreadcrumb('Roadmap data loaded successfully', 'page', {
-    todoCount: roadmap.todo.length,
-    inProgressCount: roadmap.inProgress.length,
-    doneCount: roadmap.done.length,
-  });
 
   return (
     <>
@@ -249,12 +242,8 @@ const RoadmapCard = ({ todo }: { todo: Todo }) => {
   const handleToggle = () => {
     try {
       toggle();
-      addBreadcrumb('Roadmap card toggled', 'interaction', {
-        title: title.substring(0, 30),
-        opened: !opened,
-      });
     } catch (error) {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to toggle roadmap card'),

--- a/apps/web/src/server/api/routers/config.router.ts
+++ b/apps/web/src/server/api/routers/config.router.ts
@@ -5,7 +5,7 @@ import { sql } from 'drizzle-orm';
 
 import { logEndpoint } from 'fpp/constants/logging.constant';
 
-import { captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { createTRPCRouter, publicProcedure } from 'fpp/server/api/trpc';
 
@@ -55,8 +55,8 @@ export const configRouter = createTRPCRouter({
           });
         })
         .catch((e) => {
-          // captureError already logs to console in development mode
-          captureError(
+          // recordError already logs to console in development mode
+          recordError(
             e instanceof Error ? e : new Error('Failed to fetch latest tag'),
             {
               component: 'configRouter',

--- a/apps/web/src/server/api/routers/landingpage.router.ts
+++ b/apps/web/src/server/api/routers/landingpage.router.ts
@@ -3,7 +3,7 @@ import { count } from 'drizzle-orm';
 
 import { logEndpoint } from 'fpp/constants/logging.constant';
 
-import { captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 import { createTRPCRouter, publicProcedure } from 'fpp/server/api/trpc';
 import db from 'fpp/server/db/db';
@@ -25,8 +25,8 @@ export const landingpageRouter = createTRPCRouter({
         user_count: userResult[0]?.count ?? FALLBACK_USER_COUNT,
       };
     } catch (error) {
-      // captureError already logs to console in development mode
-      captureError(
+      // recordError already logs to console in development mode
+      recordError(
         error instanceof Error
           ? error
           : new Error('Error fetching landing page analytics'),

--- a/apps/web/src/utils/app-error.ts
+++ b/apps/web/src/utils/app-error.ts
@@ -1,5 +1,10 @@
 import { TRPCClientError, type TRPCClientErrorLike } from '@trpc/client';
 
+import {
+  ATTR,
+  type EventName,
+  type TelemetryAttributes,
+} from '@fpp/shared/telemetry';
 import HyperDX from '@hyperdx/browser';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { SeverityNumber, logs } from '@opentelemetry/api-logs';
@@ -86,9 +91,9 @@ const flattenExtra = (
 // Browser-only mutable user context. HyperDX.setGlobalAttributes attaches
 // these at the RUM-session layer (for the UI's session view), not the OTLP
 // exporter — so spans/logs leaving the browser don't carry them by default.
-// We mirror the same values here and auto-merge into every captureError /
-// captureMessage / addBreadcrumb call so the data is queryable in
-// ClickHouse without callers having to thread userId/roomId everywhere.
+// We mirror the same values here and auto-merge into every recordError /
+// recordEvent call so the data is queryable in ClickHouse without callers
+// having to thread userId/roomId everywhere.
 let userContext: {
   userId?: string;
   roomId?: string;
@@ -97,13 +102,13 @@ let userContext: {
 
 const userContextAttrs = (): Record<string, string> => {
   const out: Record<string, string> = {};
-  if (userContext.userId) out['fpp.userId'] = userContext.userId;
-  if (userContext.roomId) out['fpp.roomId'] = userContext.roomId;
-  if (userContext.username) out['fpp.username'] = userContext.username;
+  if (userContext.userId) out[ATTR.USER_ID] = userContext.userId;
+  if (userContext.roomId) out[ATTR.ROOM_ID] = userContext.roomId;
+  if (userContext.username) out[ATTR.USER_NAME] = userContext.username;
   return out;
 };
 
-export const captureError = (
+export const recordError = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: Error | string | TRPCClientErrorLike<any>,
   context: ErrorContext = {},
@@ -130,6 +135,8 @@ export const captureError = (
   // Attach to active span (server-side: tRPC span, browser: HyperDX-managed)
   const span = trace.getActiveSpan();
   if (span) {
+    // TODO(otel): migrate to a log-based exception event per OTEP 4430 once the
+    // converting processor is wired into SDK init; recordException is shimmed.
     span.recordException(errorObj);
     span.setStatus({ code: SpanStatusCode.ERROR, message: errorObj.message });
     Object.entries(flatExtra).forEach(([k, v]) => span.setAttribute(k, v));
@@ -159,42 +166,25 @@ export const captureError = (
   });
 };
 
-export const captureMessage = (
-  message: string,
-  context: ErrorContext = {},
-  level: 'debug' | 'info' | 'warning' | 'error' = 'info',
+/**
+ * Record a client-only domain event as an OTEL log-based event: an INFO log
+ * record carrying `event.name` + the current user/room context + typed,
+ * registry-keyed attributes, correlated to the active trace. The browser only
+ * emits the few W events the authoritative server can't observe (spec §7);
+ * everything domain-level is emitted server-side. Never use span.addEvent
+ * (OTEP 4430).
+ */
+export const recordEvent = (
+  name: EventName,
+  attributes: TelemetryAttributes = {},
 ): void => {
-  const severity: Severity =
-    level === 'error' ? 'high' : level === 'warning' ? 'medium' : 'low';
-  const logData = {
-    component: context.component,
-    action: context.action,
-    ...context.extra,
-  };
-  switch (level) {
-    case 'debug':
-      logger.debug(logData, message);
-      break;
-    case 'info':
-      logger.info(logData, message);
-      break;
-    case 'warning':
-      logger.warn(logData, message);
-      break;
-    case 'error':
-      logger.error(logData, message);
-      break;
-  }
   getOtelLogger().emit({
-    severityNumber: SEVERITY_NUMBER[severity],
-    severityText: SEVERITY_TEXT[severity],
-    body: message,
+    severityNumber: SeverityNumber.INFO,
+    severityText: 'INFO',
     attributes: {
-      'fpp.severity': severity,
-      ...(context.component && { 'fpp.component': context.component }),
-      ...(context.action && { 'fpp.action': context.action }),
+      'event.name': name,
       ...userContextAttrs(),
-      ...flattenExtra(context.extra),
+      ...attributes,
     },
   });
 };
@@ -215,30 +205,11 @@ export const setUserContext = (ctx: {
     ...(ctx.roomId && { roomId: String(ctx.roomId) }),
     ...(ctx.username && { username: ctx.username }),
   });
-  // Mirror into the wrapper's own state so captureError / addBreadcrumb
+  // Mirror into the wrapper's own state so recordError / recordEvent
   // pick it up automatically.
   userContext = {
     ...(ctx.userId && { userId: ctx.userId }),
     ...(ctx.roomId && { roomId: String(ctx.roomId) }),
     ...(ctx.username && { username: ctx.username }),
   };
-};
-
-export const addBreadcrumb = (
-  message: string,
-  category = 'user',
-  data?: Record<string, string | number | null | boolean>,
-): void => {
-  // Breadcrumbs become INFO-level log records correlated to the active trace.
-  getOtelLogger().emit({
-    severityNumber: SeverityNumber.INFO,
-    severityText: 'INFO',
-    body: message,
-    attributes: {
-      'fpp.breadcrumb': 'true',
-      'fpp.category': category,
-      ...userContextAttrs(),
-      ...flattenExtra(data),
-    },
-  });
 };

--- a/apps/web/src/utils/room.util.ts
+++ b/apps/web/src/utils/room.util.ts
@@ -8,11 +8,8 @@ import { type RoomBase } from '@fpp/shared';
 import { type User } from '@fpp/shared';
 import confetti from 'canvas-confetti';
 
-import {
-  addBreadcrumb,
-  captureError,
-  captureMessage,
-} from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
+import { logger } from 'fpp/utils/logger';
 
 import {
   getFromLocalstorage,
@@ -38,7 +35,7 @@ function getEstimationsFromUsers(
       const roomId = useLocalstorageStore.getState().roomId;
 
       if (!userId || !roomId) {
-        captureError(
+        recordError(
           'Missing user or room ID for auto-reset',
           {
             component: 'getEstimationsFromUsers',
@@ -54,11 +51,6 @@ function getEstimationsFromUsers(
         return estimations;
       }
 
-      addBreadcrumb('Auto-resetting room due to no estimations', 'room', {
-        roomId,
-        userCount: users.length,
-      });
-
       triggerAction({
         action: 'reset',
         roomId,
@@ -67,7 +59,7 @@ function getEstimationsFromUsers(
     }
     return estimations;
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to get estimations from users'),
@@ -90,7 +82,7 @@ export function getICreateVoteFromRoomState(roomState: RoomBase): ICreateVote {
     const estimations = getEstimationsFromUsers(roomState.users);
 
     if (estimations.length === 0) {
-      captureError(
+      recordError(
         'No estimations available for vote creation',
         {
           component: 'getICreateVoteFromRoomState',
@@ -128,16 +120,9 @@ export function getICreateVoteFromRoomState(roomState: RoomBase): ICreateVote {
       wasAutoFlip: roomState.isAutoFlip,
     };
 
-    addBreadcrumb('Vote data created from room state', 'room', {
-      roomId: roomState.id,
-      estimationCount: estimations.length,
-      spectatorCount: result.amountOfSpectators,
-      duration: result.duration,
-    });
-
     return result;
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to create vote from room state'),
@@ -180,7 +165,7 @@ export function getAverageFromUsers(
       estimations.length;
     return String(Math.round(average * 10) / 10);
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to calculate average from users'),
@@ -230,15 +215,9 @@ export function getStackedEstimationsFromUsers(
       return b.amount - a.amount;
     });
 
-    addBreadcrumb('Stacked estimations calculated', 'room', {
-      userCount: users.length,
-      votingOptions: result.length,
-      average: averageStr,
-    });
-
     return result;
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to get stacked estimations from users'),
@@ -276,14 +255,10 @@ async function initializeWebAudio() {
       await audioContext.resume();
     }
 
-    addBreadcrumb('Web Audio context initialized', 'audio', {
-      state: audioContext.state,
-    });
-
     // Pre-load audio files
     await preloadAudioFiles();
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to initialize Web Audio'),
@@ -307,7 +282,6 @@ async function preloadAudioFiles() {
     for (const sound of sounds) {
       const response = await fetch(`/sounds/${sound}.wav`);
       if (!response.ok) {
-        addBreadcrumb('Failed to fetch audio file', 'audio', { sound });
         continue;
       }
 
@@ -315,16 +289,9 @@ async function preloadAudioFiles() {
       const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
       audioBuffers.set(sound, audioBuffer);
     }
-
-    addBreadcrumb('Audio files preloaded', 'audio', {
-      loadedCount: audioBuffers.size,
-    });
-  } catch (error) {
+  } catch {
     // EncodingError and similar decode failures are expected browser limitations
     // (e.g., browser doesn't support WAV codec). App gracefully degrades to silent.
-    addBreadcrumb('Audio preload failed', 'audio', {
-      errorName: error instanceof Error ? error.name : 'Unknown',
-    });
   }
 }
 
@@ -338,11 +305,10 @@ export function initializeAudioContext() {
     if (hasUserInteracted) return;
 
     hasUserInteracted = true;
-    addBreadcrumb('User interaction detected for audio', 'audio');
 
     // Initialize Web Audio API without awaiting in event handler
     initializeWebAudio().catch((error) => {
-      captureError(
+      recordError(
         error instanceof Error
           ? error
           : new Error('Failed to initialize audio after user interaction'),
@@ -367,17 +333,11 @@ export function initializeAudioContext() {
 
 function playWebAudioSound(sound: 'join' | 'leave' | 'success' | 'tick') {
   if (audioContext?.state !== 'running' || !hasUserInteracted) {
-    addBreadcrumb('Web Audio not available', 'audio', {
-      hasContext: !!audioContext,
-      contextState: audioContext?.state ?? 'null',
-      hasInteraction: hasUserInteracted,
-    });
     return false;
   }
 
   const buffer = audioBuffers.get(sound);
   if (!buffer) {
-    addBreadcrumb('Audio buffer not found', 'audio', { sound });
     return false;
   }
 
@@ -392,10 +352,9 @@ function playWebAudioSound(sound: 'join' | 'leave' | 'success' | 'tick') {
     gainNode.connect(audioContext.destination);
 
     source.start();
-    addBreadcrumb('Web Audio sound played', 'audio', { sound });
     return true;
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to play Web Audio sound'),
@@ -413,9 +372,6 @@ function playWebAudioSound(sound: 'join' | 'leave' | 'success' | 'tick') {
 // Fallback to HTML5 Audio
 function playHtml5Sound(sound: 'join' | 'leave' | 'success' | 'tick') {
   if (!hasUserInteracted) {
-    addBreadcrumb('HTML5 Audio blocked - no user interaction', 'audio', {
-      sound,
-    });
     return;
   }
 
@@ -426,42 +382,34 @@ function playHtml5Sound(sound: 'join' | 'leave' | 'success' | 'tick') {
     const playPromise = audio.play();
 
     if (playPromise !== undefined) {
-      playPromise
-        .then(() => {
-          addBreadcrumb('HTML5 Audio sound played', 'audio', { sound });
-        })
-        .catch((error) => {
-          if (
-            error instanceof Error &&
-            (error.name === 'NotAllowedError' ||
-              error.name === 'NotSupportedError')
-          ) {
-            // NotAllowedError: Browser autoplay policy blocked audio
-            // NotSupportedError: Browser doesn't support audio format (expected limitation)
-            addBreadcrumb('HTML5 Audio blocked or not supported', 'audio', {
-              sound,
-              errorName: error.name,
-            });
-          } else {
-            captureError(
-              error instanceof Error
-                ? error
-                : new Error('Failed to play HTML5 sound'),
-              {
-                component: 'playHtml5Sound',
-                action: 'play',
-                extra: {
-                  sound,
-                  errorName: error instanceof Error ? error.name : 'Unknown',
-                },
+      playPromise.catch((error) => {
+        if (
+          error instanceof Error &&
+          (error.name === 'NotAllowedError' ||
+            error.name === 'NotSupportedError')
+        ) {
+          // NotAllowedError: Browser autoplay policy blocked audio
+          // NotSupportedError: Browser doesn't support audio format (expected limitation)
+        } else {
+          recordError(
+            error instanceof Error
+              ? error
+              : new Error('Failed to play HTML5 sound'),
+            {
+              component: 'playHtml5Sound',
+              action: 'play',
+              extra: {
+                sound,
+                errorName: error instanceof Error ? error.name : 'Unknown',
               },
-              'low',
-            );
-          }
-        });
+            },
+            'low',
+          );
+        }
+      });
     }
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to create HTML5 audio'),
@@ -480,7 +428,6 @@ function playSound(sound: 'join' | 'leave' | 'success' | 'tick') {
     if (getFromLocalstorage('isPlaySound') === 'false') return;
 
     if (!hasUserInteracted) {
-      addBreadcrumb('Audio blocked - no user interaction', 'audio', { sound });
       return;
     }
 
@@ -490,7 +437,7 @@ function playSound(sound: 'join' | 'leave' | 'success' | 'tick') {
       playHtml5Sound(sound);
     }
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error ? error : new Error('Failed to play sound'),
       {
         component: 'playSound',
@@ -522,13 +469,8 @@ function notify({
       title,
       message,
     });
-    addBreadcrumb('Notification shown', 'notification', {
-      color,
-      title,
-      autoClose: autoClose ?? 5000,
-    });
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error ? error : new Error('Failed to show notification'),
       {
         component: 'notify',
@@ -570,11 +512,6 @@ export function notifyOnRoomChanges({
           oldUser.isSpectator !== newUser.isSpectator)
       ) {
         playSound('tick');
-        addBreadcrumb('User state changed', 'room', {
-          userId: newUser.id,
-          estimationChanged: oldUser.estimation !== newUser.estimation,
-          spectatorChanged: oldUser.isSpectator !== newUser.isSpectator,
-        });
       }
     }
 
@@ -587,32 +524,23 @@ export function notifyOnRoomChanges({
       const isUnanimous =
         estimations.length > 1 && new Set(estimations).size === 1;
 
-      addBreadcrumb('Room flipped', 'room', {
-        estimationCount: estimations.length,
-        isUnanimous,
-      });
-
       if (isUnanimous) {
         confetti({
           particleCount: 200,
           spread: 80,
           origin: { y: 0.4 },
-        })
-          ?.then(() => {
-            addBreadcrumb('Confetti celebration triggered', 'room');
-          })
-          .catch((error) => {
-            captureError(
-              error instanceof Error
-                ? error
-                : new Error('Failed to trigger confetti'),
-              {
-                component: 'notifyOnRoomChanges',
-                action: 'confetti',
-              },
-              'low',
-            );
-          });
+        })?.catch((error) => {
+          recordError(
+            error instanceof Error
+              ? error
+              : new Error('Failed to trigger confetti'),
+            {
+              component: 'notifyOnRoomChanges',
+              action: 'confetti',
+            },
+            'low',
+          );
+        });
       }
     }
 
@@ -662,7 +590,7 @@ export function notifyOnRoomChanges({
       return;
     }
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to process room changes'),
@@ -693,12 +621,6 @@ export function executeLeave({
   router?: NextRouter;
 }) {
   try {
-    addBreadcrumb('Executing room leave', 'room', {
-      roomId,
-      userId,
-      hasRouter: !!router,
-    });
-
     // Cleanup room State
     const { setRoomId, setRoomName } = useLocalstorageStore.getState();
     setRoomId(null);
@@ -713,29 +635,24 @@ export function executeLeave({
 
     // Navigate to homepage
     if (router) {
-      router
-        .push('/')
-        .then(() => {
-          addBreadcrumb('Navigation to homepage successful', 'navigation');
-        })
-        .catch((error) => {
-          captureError(
-            error instanceof Error
-              ? error
-              : new Error('Failed to navigate to homepage after leave'),
-            {
-              component: 'executeLeave',
-              action: 'navigate',
-              extra: { roomId, userId },
-            },
-            'medium',
-          );
-        });
+      router.push('/').catch((error) => {
+        recordError(
+          error instanceof Error
+            ? error
+            : new Error('Failed to navigate to homepage after leave'),
+          {
+            component: 'executeLeave',
+            action: 'navigate',
+            extra: { roomId, userId },
+          },
+          'medium',
+        );
+      });
     } else if (typeof window !== 'undefined') {
       window.location.href = '/';
     }
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to execute room leave'),
@@ -754,19 +671,12 @@ export function executeKick(
   router?: NextRouter,
 ): void {
   try {
-    addBreadcrumb('Executing kick', 'room', {
-      scenario,
-      hasRouter: !!router,
-    });
     if (scenario !== 'kick_notification') {
-      captureMessage(
+      // The server emits the authoritative user.kicked event; this is just
+      // client-side narration of the redirect.
+      logger.warn(
+        { component: 'executeKick', action: 'kick', scenario },
         `User was kicked from room (${scenario}), redirecting to homepage`,
-        {
-          component: 'executeKick',
-          action: 'kick',
-          extra: { scenario },
-        },
-        'warning',
       );
     }
 
@@ -789,30 +699,25 @@ export function executeKick(
     // Use router if provided, otherwise fallback to window.location
     setTimeout(() => {
       if (router) {
-        router
-          .push('/')
-          .then(() => {
-            addBreadcrumb('Navigation after kick successful', 'navigation');
-          })
-          .catch((error) => {
-            captureError(
-              error instanceof Error
-                ? error
-                : new Error('Failed to navigate after kick'),
-              {
-                component: 'executeKick',
-                action: 'navigate',
-                extra: { scenario },
-              },
-              'medium',
-            );
-          });
+        router.push('/').catch((error) => {
+          recordError(
+            error instanceof Error
+              ? error
+              : new Error('Failed to navigate after kick'),
+            {
+              component: 'executeKick',
+              action: 'navigate',
+              extra: { scenario },
+            },
+            'medium',
+          );
+        });
       } else if (typeof window !== 'undefined') {
         window.location.href = '/';
       }
     }, 200);
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error ? error : new Error('Failed to execute kick'),
       {
         component: 'executeKick',
@@ -832,11 +737,6 @@ export function executeRoomNameChange({
   router?: NextRouter;
 }): void {
   try {
-    addBreadcrumb('Executing room name change', 'room', {
-      newRoomName,
-      hasRouter: !!router,
-    });
-
     // Update local storage with new room name
     const { setRoomName, setRecentRoom } = useLocalstorageStore.getState();
     setRoomName(newRoomName);
@@ -851,29 +751,24 @@ export function executeRoomNameChange({
 
     // Navigate to new room URL
     if (router) {
-      router
-        .push(`/room/${newRoomName}`)
-        .then(() => {
-          addBreadcrumb('Navigation to renamed room successful', 'navigation');
-        })
-        .catch((error) => {
-          captureError(
-            error instanceof Error
-              ? error
-              : new Error('Failed to navigate to renamed room'),
-            {
-              component: 'executeRoomNameChange',
-              action: 'navigate',
-              extra: { newRoomName },
-            },
-            'medium',
-          );
-        });
+      router.push(`/room/${newRoomName}`).catch((error) => {
+        recordError(
+          error instanceof Error
+            ? error
+            : new Error('Failed to navigate to renamed room'),
+          {
+            component: 'executeRoomNameChange',
+            action: 'navigate',
+            extra: { newRoomName },
+          },
+          'medium',
+        );
+      });
     } else if (typeof window !== 'undefined') {
       window.location.href = `/room/${newRoomName}`;
     }
   } catch (error) {
-    captureError(
+    recordError(
       error instanceof Error
         ? error
         : new Error('Failed to execute room name change'),

--- a/apps/web/src/utils/send-track-event.util.ts
+++ b/apps/web/src/utils/send-track-event.util.ts
@@ -1,6 +1,6 @@
 import { logEndpoint } from 'fpp/constants/logging.constant';
 
-import { captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 export function sendTrackEvent({
   event,
@@ -30,7 +30,7 @@ export function sendTrackEvent({
       });
     }
   } catch (e) {
-    captureError(
+    recordError(
       e instanceof Error ? e : new Error('Failed to track event'),
       {
         component: 'sendTrackEvent',

--- a/docs/otel-migration/05-observability-v2.md
+++ b/docs/otel-migration/05-observability-v2.md
@@ -231,8 +231,12 @@ Emitted via `recordEvent`. `S` = fpp-server (authoritative, primary), `W` = web 
 | `ws.connected` | Socket open | `room.id`, `user.id` | S |
 | `ws.disconnected` | Socket close (non-normal) | `room.id`, `user.id`, `close.reason` | S |
 | `ws.reconnected` | Action queue flush after reconnect | `room.id`, `user.id` | W |
+| `ws.reconnect_exhausted` | Client reconnect attempts exhausted | `room.id`, `user.id` | W |
+| `ws.recovery_reload` | Connection-health watchdog forced a page reload | `room.id`, `user.id` | W |
 
 `heartbeat` is intentionally **not** an event — it's noise. It feeds presence/liveness only.
+
+> `ws.reconnect_exhausted` and `ws.recovery_reload` are client-only recovery signals the authoritative server cannot observe (the browser gave up reconnecting / force-reloaded itself). Added beyond the original §7 set during P4.
 
 ---
 

--- a/packages/shared/src/telemetry/events.ts
+++ b/packages/shared/src/telemetry/events.ts
@@ -31,6 +31,9 @@ export const EVENT = {
   WS_CONNECTED: 'ws.connected',
   WS_DISCONNECTED: 'ws.disconnected',
   WS_RECONNECTED: 'ws.reconnected',
+  // Client-only (W) connection-recovery signals the server can't observe.
+  WS_RECONNECT_EXHAUSTED: 'ws.reconnect_exhausted',
+  WS_RECOVERY_RELOAD: 'ws.recovery_reload',
 } as const;
 
 /** Every valid `event.name`. A raw `'vote.casted'` typo is not assignable. */


### PR DESCRIPTION
## Observability v2 — Phase 4 (web)

Clean break of the browser facade, mirroring the server work in P3. The browser emits **events only** (never metrics — the server is authoritative).

### Facade (`apps/web/src/utils/app-error.ts`)
- `captureError` → **`recordError`** (108 call sites). Added a `// TODO(otel)` OTEP-4430 note on the `recordException` shim.
- Added **`recordEvent`** (log-based events, auto-merges the user/room context).
- **Deleted** `captureMessage` + `addBreadcrumb`.
- userContext OTLP keys → domain-first via the registry: `fpp.userId`→`user.id`, `fpp.roomId`→`room.id`, `fpp.username`→`user.name`. The HyperDX RUM `setGlobalAttributes` keys stay as the SDK expects.

### Breadcrumbs removed (109)
Sentry-era debugging breadcrumbs are deprecated. The authoritative server now emits the room/vote/round domain events, and traces cover the WS flow, so they're redundant. Removed wholesale. The 2 operator-narration `captureMessage` calls → web `logger.warn` (console), not OTEL.

### Client-only events kept (the only signals the server can't observe)
- `ws.reconnected` — action-queue flush after a reconnect
- `ws.reconnect_exhausted` — `react-use-websocket` gave up (`onReconnectStop`)
- `ws.recovery_reload` — connection-health watchdog forced a page reload

The latter two are **added to the shared `EVENT` registry** (W events) and spec §7. (Per a deliberate decision to preserve client-only connection-recovery debugging beyond the original §7 set.)

### Verification
`bun run validate` green for web + shared + server (format, lint, typecheck, **next build** compiled). No `captureError`/`captureMessage`/`addBreadcrumb` references remain in `apps/web`. The server (which consumes the `EVENT` registry) still builds — the 2 new events are additive.

### Next
P5 analytics RED metrics + `telemetry_taxonomy.py`; P6 ESLint/rules enforcement (server + meter bans, `.claude/rules/observability.md`, CLAUDE.md); P7 SDK Views allowlist.