### PR TITLE
feat: analytics endpoint RED metrics + taxonomy — Observability v2 P5

### DIFF
--- a/fpp-analytics/main.py
+++ b/fpp-analytics/main.py
@@ -13,7 +13,7 @@ from starlette.responses import Response
 from config import ANALYTICS_SECRET_TOKEN
 from routers import analytics, health, room
 from util.error_capture import ErrorContext, capture_error
-from util.telemetry import init_telemetry, shutdown_telemetry
+from util.telemetry import init_telemetry, record_request, shutdown_telemetry
 
 
 # Custom JSON formatter to match Pino structure
@@ -83,6 +83,14 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         duration_ms = (time.perf_counter() - start_time) * 1000
 
+        # Endpoint RED metrics. Use the route template (not the raw path) as the
+        # endpoint label so /room/{room_id}/stats stays one low-cardinality
+        # series. Skip /health — high-frequency probe, excluded from spans too.
+        if request.url.path != "/health":
+            route = request.scope.get("route")
+            endpoint = getattr(route, "path", None) or "unmatched"
+            record_request(endpoint, response.status_code, duration_ms / 1000)
+
         # Skip logging for /health 200 OK responses
         if request.url.path == "/health" and response.status_code == 200:
             return response
@@ -134,14 +142,14 @@ def verify_auth(authorization: str = Header(None)) -> bool:
 # be populated before the app starts handling requests. Doing this inside
 # `lifespan` is too late — the middleware stack has already been frozen
 # and the instrumentor's middleware silently never runs.
-_tracer_provider, _logger_provider = init_telemetry()
+_tracer_provider, _logger_provider, _meter_provider = init_telemetry()
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Flush OTEL batches on shutdown. Provider init happens at import time."""
     yield
-    shutdown_telemetry(_tracer_provider, _logger_provider)
+    shutdown_telemetry(_tracer_provider, _logger_provider, _meter_provider)
 
 
 # Global exception handler for unhandled system errors.

--- a/fpp-analytics/update_readmodel.py
+++ b/fpp-analytics/update_readmodel.py
@@ -30,7 +30,7 @@ from util.telemetry import init_telemetry, shutdown_telemetry  # noqa: E402
 
 # Bootstrap OTEL providers — same endpoint as the FastAPI server. The sleep
 # loop in the sidecar means init runs once per python invocation.
-_tracer_provider, _logger_provider = init_telemetry()
+_tracer_provider, _logger_provider, _meter_provider = init_telemetry()
 
 DATA_DIR = Path(os.getenv("DATA_DIR", "./data"))
 UPTIMEKUMA_PUSH_URL = os.getenv("UPTIMEKUMA_PUSH_URL")
@@ -239,8 +239,8 @@ def main() -> None:
         push_uptimekuma("down", str(e))
         sys.exit(1)
     finally:
-        # Ensure OTEL spans/logs flush before exit.
-        shutdown_telemetry(_tracer_provider, _logger_provider)
+        # Ensure OTEL spans/logs/metrics flush before exit.
+        shutdown_telemetry(_tracer_provider, _logger_provider, _meter_provider)
 
 
 if __name__ == "__main__":

--- a/fpp-analytics/util/telemetry.py
+++ b/fpp-analytics/util/telemetry.py
@@ -9,17 +9,26 @@ import contextlib
 import logging
 import os
 
+from opentelemetry import metrics as metrics_api
 from opentelemetry import trace
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter,
+)
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter,
 )
+from opentelemetry.metrics import Counter, Histogram
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from util.telemetry_taxonomy import ATTR, METRIC
 
 SERVICE_NAME = os.getenv("OTEL_SERVICE_NAME", "fpp-analytics")
 SERVICE_VERSION = os.getenv("OTEL_SERVICE_VERSION", "local")
@@ -35,20 +44,26 @@ OTLP_ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4319"
 _resource = Resource.create(
     {
         "service.name": SERVICE_NAME,
+        # Groups the three fpp services as one app in HyperDX.
+        "service.namespace": "free-planning-poker",
         "service.version": SERVICE_VERSION,
         "deployment.environment": ENVIRONMENT,
     }
 )
 
 
-_initialized: tuple[TracerProvider, LoggerProvider] | None = None
+_initialized: tuple[TracerProvider, LoggerProvider, MeterProvider] | None = None
+
+# Endpoint RED instruments, created once in init_telemetry. None until then.
+_request_count: Counter | None = None
+_request_duration: Histogram | None = None
 
 
-def init_telemetry() -> tuple[TracerProvider, LoggerProvider]:
-    """Wire trace + log providers. Idempotent — safe to call multiple times
-    (returns the existing providers on re-entry instead of adding duplicate
-    handlers to the root logger)."""
-    global _initialized
+def init_telemetry() -> tuple[TracerProvider, LoggerProvider, MeterProvider]:
+    """Wire trace + log + metric providers. Idempotent — safe to call multiple
+    times (returns the existing providers on re-entry instead of adding
+    duplicate handlers to the root logger)."""
+    global _initialized, _request_count, _request_duration
     if _initialized is not None:
         return _initialized
 
@@ -72,12 +87,45 @@ def init_telemetry() -> tuple[TracerProvider, LoggerProvider]:
     otel_handler = LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
     logging.getLogger().addHandler(otel_handler)
 
-    _initialized = (tracer_provider, logger_provider)
+    # Metrics: endpoint RED. Periodic reader exports every 60s over OTLP HTTP.
+    meter_provider = MeterProvider(
+        resource=_resource,
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=f"{OTLP_ENDPOINT}/v1/metrics"),
+                export_interval_millis=60_000,
+            )
+        ],
+    )
+    metrics_api.set_meter_provider(meter_provider)
+    meter = meter_provider.get_meter(SERVICE_NAME)
+    _request_count = meter.create_counter(METRIC.REQUEST_COUNT, unit="{request}")
+    _request_duration = meter.create_histogram(METRIC.REQUEST_DURATION, unit="s")
+
+    _initialized = (tracer_provider, logger_provider, meter_provider)
     return _initialized
 
 
+def record_request(endpoint: str, status_code: int, duration_seconds: float) -> None:
+    """Record endpoint RED: one count (by endpoint + ok|error outcome) and the
+    handler duration. The single metric chokepoint — callers never touch a
+    meter directly. No-op until init_telemetry has run."""
+    if _request_count is None or _request_duration is None:
+        return
+    outcome = "error" if status_code >= 500 else "ok"
+    count_attrs: dict[str, str] = {ATTR.ENDPOINT: endpoint, ATTR.OUTCOME: outcome}
+    if outcome == "error":
+        # Bounded low-cardinality enum on the error path (HTTP status, never a
+        # message).
+        count_attrs[ATTR.ERROR_TYPE] = str(status_code)
+    _request_count.add(1, count_attrs)
+    _request_duration.record(duration_seconds, {ATTR.ENDPOINT: endpoint})
+
+
 def shutdown_telemetry(
-    tracer_provider: TracerProvider | None, logger_provider: LoggerProvider | None
+    tracer_provider: TracerProvider | None,
+    logger_provider: LoggerProvider | None,
+    meter_provider: MeterProvider | None = None,
 ) -> None:
     """Best-effort flush on process exit."""
     if tracer_provider is not None:
@@ -86,3 +134,6 @@ def shutdown_telemetry(
     if logger_provider is not None:
         with contextlib.suppress(Exception):
             logger_provider.shutdown()
+    if meter_provider is not None:
+        with contextlib.suppress(Exception):
+            meter_provider.shutdown()

--- a/fpp-analytics/util/telemetry_taxonomy.py
+++ b/fpp-analytics/util/telemetry_taxonomy.py
@@ -1,0 +1,30 @@
+"""Typed telemetry taxonomy for fpp-analytics.
+
+Python can't import the TypeScript registry (`@fpp/shared/telemetry`), so this
+is the hand-kept parallel of the small subset analytics actually emits — the
+attribute keys and metric names. Keep names in sync with the TS source of truth;
+analytics-only keys (`endpoint`) live here.
+
+See docs/otel-migration/05-observability-v2.md §4-5/§10.
+"""
+
+from typing import Final
+
+
+class ATTR:
+    """Attribute keys. snake_case, domain-first; `fpp.*` for facade metadata."""
+
+    ENDPOINT: Final = "endpoint"  # route template, e.g. /room/{room_id}/stats
+    OUTCOME: Final = "outcome"  # ok | error
+    ERROR_TYPE: Final = "error.type"  # bounded: HTTP status on the error path
+    # Facade-proprietary cross-cutting metadata (mirrors the TS registry).
+    FPP_COMPONENT: Final = "fpp.component"
+    FPP_ACTION: Final = "fpp.action"
+    FPP_SEVERITY: Final = "fpp.severity"
+
+
+class METRIC:
+    """Metric instrument names. dot-namespaced, instrument-suffixed, UCUM units."""
+
+    REQUEST_COUNT: Final = "fpp.analytics.request.count"  # counter, {request}
+    REQUEST_DURATION: Final = "fpp.analytics.request.duration"  # histogram, s


### PR DESCRIPTION
## Observability v2 — Phase 5 (fpp-analytics)

Adds metrics to the Python analytics service: endpoint RED + a parallel typed taxonomy.

### MeterProvider (`util/telemetry.py`)
- `MeterProvider` with `PeriodicExportingMetricReader` + `OTLPMetricExporter` (proto over HTTP) → `${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics`, 60s. Mirrors the existing trace/log provider setup; the `init_telemetry` idempotent triple now returns the meter provider too, and `shutdown_telemetry` flushes it (callers + `update_readmodel.py` updated).
- `service.namespace=free-planning-poker` added to the resource (constraint #9).

### Endpoint RED (in the existing request-logging middleware)
- `fpp.analytics.request.count` — counter, by `endpoint` + `outcome` (`ok`/`error`), with the HTTP status as `error.type` on the 5xx path.
- `fpp.analytics.request.duration` — histogram (`s`), by `endpoint`.
- `endpoint` is the **route template** (`request.scope["route"].path`), not the raw path, so `/room/{room_id}/stats` stays one low-cardinality series. `/health` is excluded (high-frequency probe, already excluded from spans). `record_request` is the single chokepoint — callers never touch a meter.

### Taxonomy (`util/telemetry_taxonomy.py`)
Hand-kept parallel of the TS registry subset analytics emits (`ATTR.ENDPOINT/OUTCOME/ERROR_TYPE` + the `fpp.*` facade keys; `METRIC` request names). Per spec §5, Python can't import the TS registry; codegen parity is deferred.

> The Python error facade verbs (`capture_error`/`add_error_breadcrumb`) are intentionally **not** renamed here — the clean-break rename in §6/§17 targets the TS camelCase verbs. P5 scope is metrics + taxonomy only.

### Verification
`bun run fpp-analytics:validate` green (ruff format + lint + mypy). Ran the server against local ClickStack and confirmed: `request.count` (`endpoint=/` ok×2, `unmatched` ok×1) + `request.duration` histogram landed, `service.namespace=free-planning-poker` set, `/health` excluded, no high-cardinality attributes.

### Next
P6 enforcement (ESLint server bans + `.claude/rules/observability.md` + CLAUDE.md + web `service.namespace`); P7 SDK Views allowlist.