### PR TITLE
chore: observability enforcement + docs — Observability v2 P6

### DIFF
--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -1,0 +1,83 @@
+---
+paths:
+  - packages/shared/src/telemetry/**
+  - apps/server/src/telemetry.ts
+  - apps/server/src/utils/app-error.ts
+  - apps/server/src/utils/instrument-action.ts
+  - apps/server/src/room.entity.ts
+  - apps/server/src/room.state.ts
+  - apps/server/src/message.handler.ts
+  - apps/web/src/utils/app-error.ts
+  - apps/web/instrumentation.ts
+  - apps/web/instrumentation-client.ts
+  - fpp-analytics/util/telemetry.py
+  - fpp-analytics/util/telemetry_taxonomy.py
+  - fpp-analytics/util/error_capture.py
+---
+
+# Observability (OTEL → ClickStack/HyperDX)
+
+Full spec: `docs/otel-migration/05-observability-v2.md`. This rule is the
+working summary — when in doubt, the spec wins.
+
+## Single typed taxonomy
+
+Every attribute key, event name and metric name originates in
+`packages/shared/src/telemetry/` (`ATTR` / `EVENT` / `METRIC`), consumed by web
++ server. Python mirrors the subset it emits in
+`fpp-analytics/util/telemetry_taxonomy.py` (hand-kept). **No raw telemetry
+string literal anywhere else** — pass `ATTR.*` keys, `EVENT.*` names, `METRIC.*`
+descriptors. A raw `'roomId'` must not typecheck. `event.name` (the OTEL-reserved
+event key) is the one allowed literal, inside `recordEvent` only.
+
+## Which signal? (decision matrix, spec §3)
+
+- **Span / span attribute** — duration + static facts of an operation. The WS
+  span is created by `instrumentAction`.
+- **Log-based Event** (`recordEvent(EVENT.X, attrs)`) — a discrete, named,
+  business occurrence to count/filter/drill into. Carries high-cardinality dims
+  (`room.id`, `user.id`, `vote.value`). Never `span.addEvent()` (OTEP 4430).
+- **Metric** (`metrics.*`) — numeric series for dashboards/alerts.
+  **Low-cardinality labels only — never `room.id` or `user.id`.**
+- **Plain log** (`log.*` Pino on server, `logger.*` on web) — operator
+  narration (invalid message, fail-open warning). Not OTEL.
+- **Exception** (`recordError(err, ctx, sev)`) — error conditions.
+
+## Naming (spec §4)
+
+snake_case within `.`-delimited segments. **Domain-first, no prefix** for
+business concepts (`room.*`, `user.*`, `vote.*`, `round.*`, `action.type`,
+`outcome`, `close.reason`). **`fpp.*`** only for facade cross-cutting metadata
+(`fpp.component`, `fpp.action`, `fpp.severity`, `fpp.ws.connection_id`).
+`otel.*` is forbidden. Metric names: dot-namespaced, instrument-suffixed, never
+`_total`, UCUM units in metadata.
+
+## Facade verbs (clean break — no Sentry-era verbs)
+
+`recordError` / `recordEvent` / `metrics.*` only. **No `captureMessage`,
+`captureError`, `addBreadcrumb`** in TS. ESLint bans importing `logs`
+(`@opentelemetry/api-logs`), `metrics` (`@opentelemetry/api`) and
+`@hyperdx/browser` outside the facade/telemetry/instrumentation files.
+
+## Server emission rules (authoritative source)
+
+- **fpp-server owns all metrics.** The browser emits **events only**.
+- **Domain events + domain metrics fire at the state-mutation chokepoint** in
+  `room.entity.ts` / `room.state.ts`, **not** `message.handler.ts` — so timer/
+  cron mutations (auto-flip, the 30-min sweep, empty-room close) are measured
+  too. One source per domain event.
+- `instrumentAction` owns ONLY transport/RED (trace continuation, span,
+  `fpp.action.count`/`duration`, ok|error outcome). `heartbeat` bypasses it.
+- The three `*.active` gauges are **ObservableUpDownCounters** whose callbacks
+  sample `roomState`'s Maps. Never manual ±1. Event-style totals
+  (created/closed/vote.cast/round.flipped) are synchronous Counters.
+- `recordError` keeps `span.recordException()` for now — `// TODO(otel)` OTEP
+  4430. New in-flight occurrences use `recordEvent`, never `span.addEvent()`.
+
+## Taxonomy reference
+
+Events (spec §7) and metrics (spec §8) are the contract — add a new
+`EVENT`/`METRIC`/`ATTR` to the registry first, then emit. `vote.cleared` fires
+for a null estimate (deselect); `vote.cast` for non-null only. Cardinality
+budget (spec §13): each metric's label cross-product stays well under 200; SDK
+Views enforce a per-metric attribute allowlist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,8 @@ Room state exists in THREE places:
 
 | Service | Error Handling | Context attributes |
 |---------|----------------|--------------------|
-| Next.js | `captureError()` → OTEL span exception + log record | component, action, userId, roomId |
-| fpp-server | `captureError()` → OTEL span exception + log record | roomId, userId, action |
+| Next.js | `recordError()` → OTEL span exception + log record | component, action, userId, roomId |
+| fpp-server | `recordError()` → OTEL span exception + log record | roomId, userId, action |
 | fpp-analytics | `capture_error()` → OTEL span exception + log record | endpoint, calculation |
 
 ### Development Workflow Commands
@@ -370,7 +370,7 @@ useEffect(() => {
 ```
 
 #### 2. `react-hooks/error-boundaries` - Valid for:
-- Breadcrumb-equivalent log emission (not error handling)
+- Event log emission via `recordEvent` (not error handling)
 - Component-level logging
 
 #### 3. `react-hooks/purity` - Valid for:
@@ -501,7 +501,7 @@ const roomState = useRoomStore();
 const mutation = api.room.joinRoom.useMutation({
   onSuccess: (data) => { /* handle success */ },
   onError: (error) => {
-    captureError(error, { component: 'X', action: 'Y' }, 'high');
+    recordError(error, { component: 'X', action: 'Y' }, 'high');
   },
 });
 ```
@@ -518,10 +518,10 @@ triggerAction({
 ```
 
 ### Error Handling
-Use the wrapper with breadcrumbs (emits OTEL log records correlated by trace_id):
+Use the facade verbs (emit OTEL log records correlated by trace_id):
 ```typescript
-addBreadcrumb('User action', 'component', { userId, roomId });
-captureError(error, { component: 'ComponentName', action: 'actionName' }, 'high');
+recordEvent(EVENT.WS_RECONNECTED); // typed, client-only domain event
+recordError(error, { component: 'ComponentName', action: 'actionName' }, 'high');
 ```
 
 ## Testing & Verification
@@ -555,22 +555,36 @@ Local builds require `SKIP_ENV_VALIDATION=1` — environment variables are injec
 ## Error Handling Standards (OpenTelemetry → HyperDX)
 
 Sentry has been replaced by a self-hosted OTEL stack (ClickStack + HyperDX on the
-VPS). The wrapper API in `apps/web/src/utils/app-error.ts` is unchanged — only the
-internals swapped to OTEL span exception recording + log records. See
-`docs/otel-migration/` for the full migration record.
+VPS). **Observability v2** then added metrics + log-based events + a single typed
+taxonomy — see `docs/otel-migration/05-observability-v2.md` (the source of truth)
+and `.claude/rules/observability.md`. The facade was re-founded on OTEL-native
+verbs (clean break, no Sentry-era aliases):
+
+- `recordError(err, ctx, sev)` — exceptions (span exception + correlated log).
+- `recordEvent(EVENT.X, attrs)` — log-based domain events (typed, registry-keyed).
+- `metrics.*` — typed instrument handles (fpp-server only; the browser emits
+  events, never metrics).
+- Operator narration → `log.*` (Pino, server) / `logger.*` (web), not OTEL.
+- `captureMessage` / `addBreadcrumb` are **gone**.
+
+Every attribute key / event name / metric name originates in
+`@fpp/shared/telemetry` (`ATTR` / `EVENT` / `METRIC`). No raw telemetry string
+literals elsewhere.
 
 ### Import Rule (Enforced by ESLint)
 ```typescript
-// ✅ Correct - use the wrapper
-import { captureError, captureMessage, addBreadcrumb } from 'fpp/utils/app-error';
+// ✅ Correct - use the facade
+import { recordError, recordEvent } from 'fpp/utils/app-error';
 
-// ❌ BANNED - direct OTEL log emission outside the wrapper
+// ❌ BANNED - direct OTEL log emission outside the facade
 import { logs } from '@opentelemetry/api-logs';
+// ❌ BANNED - meters are created only in telemetry.ts
+import { metrics } from '@opentelemetry/api';
 // ❌ BANNED - direct HyperDX SDK calls (init lives in instrumentation-client.ts)
 import HyperDX from '@hyperdx/browser';
 ```
 
-### When to Use captureError
+### When to Use recordError
 
 **Capture:**
 - System errors (database, server crashes)
@@ -600,7 +614,7 @@ Informational? → low
 ```typescript
 mutation.mutate(data, {
   onError: (error) => {
-      captureError(error, {
+      recordError(error, {
         component: 'ComponentName',
         action: 'actionName',
         extra: { errorCode }
@@ -612,46 +626,50 @@ mutation.mutate(data, {
 });
 ```
 
-### captureError Usage
+### recordError Usage
 
 ```typescript
 // Good: Provides context
-captureError(error, {
+recordError(error, {
   component: 'UserProfile',
   action: 'updateSettings',
   extra: { userId, settingKey }
 }, 'high');
 
 // Bad: No context
-captureError(error);
+recordError(error);
 
 // Good: Capturing user input error to fix frontend validations
 if (email.length > 100) {
-  captureError('Email too long', { component: 'Form' }, 'medium');
+  recordError('Email too long', { component: 'Form' }, 'medium');
 }
 
 // Good: Capturing validation logic bug
 try {
   return value.trim().length > 50;
 } catch (error) {
-  captureError(error, { component: 'Form', action: 'validate' }, 'low');
+  recordError(error, { component: 'Form', action: 'validate' }, 'low');
 }
 ```
 
-### Breadcrumb Guidelines
+### Event Guidelines (`recordEvent`)
 
-**Use breadcrumbs for:**
-- Navigation events (page changes, route transitions)
-- WebSocket lifecycle (connect, disconnect, reconnect)
-- Critical user actions (create room, join room, vote)
-- State transitions (connection health, heartbeat pings)
+Breadcrumbs are gone. Discrete business occurrences are now **log-based events**
+emitted via `recordEvent(EVENT.X, attrs)` — typed names from the
+`@fpp/shared/telemetry` registry, never `span.addEvent()` (OTEP 4430).
 
-**Don't use breadcrumbs for:**
-- Every render or effect
-- Repeated/frequent events (individual keystrokes, mouse moves)
-- Events that don't help debug errors
+**Signal discipline (no reflexive "log everything"):**
+- **Domain events** (`room.joined`, `vote.cast`, `round.flipped`, …) are emitted
+  by **fpp-server** at the state-mutation chokepoint (`room.entity`/`room.state`)
+  — the authoritative source. Don't mirror them from the browser.
+- The **browser emits only client-only events** the server can't observe:
+  `ws.reconnected`, `ws.reconnect_exhausted`, `ws.recovery_reload`.
+- Operator narration (invalid message, fail-open warnings) → plain logs
+  (`log.*` / `logger.*`), not events.
+- Never an event per render/effect, keystroke, or high-frequency tick.
 
-**Current usage:** 21 files use breadcrumbs - mostly in hooks (WebSocket, heartbeat, connection health) and navigation. This is appropriate for central, high-level operations.
+Add a new event/attribute/metric to the registry **first**, then emit it. See
+`.claude/rules/observability.md` for the full decision matrix.
 
 ## Error Handling Implementation Guide
 
@@ -672,7 +690,7 @@ All Next.js API route handlers (`apps/web/src/pages/api/*.ts`) must wrap their l
 
 ```typescript
 import { type NextApiRequest, type NextApiResponse } from '@trpc/server/adapters/next';
-import { captureError } from 'fpp/utils/app-error';
+import { recordError } from 'fpp/utils/app-error';
 
 const ApiHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -692,7 +710,7 @@ const ApiHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(200).json({ success: true });
   } catch (error) {
     // Capture error with context
-    captureError(
+    recordError(
       error instanceof Error ? error : new Error('Operation failed'),
       {
         component: 'api-route-name',
@@ -719,13 +737,13 @@ export default ApiHandler;
 
 **Key Points:**
 - Wrap entire handler function in try-catch
-- Capture errors with component/action context using `captureError`
+- Capture errors with component/action context using `recordError`
 - Return HTTP 500 with safe error message
 - Use 'high' severity for API failures (blocks user action)
 
 ### tRPC Router Error Handling (CustomTRPCError)
 
-**IMPORTANT:** tRPC routers use CustomTRPCError for centralized error capture. Do NOT use try-catch or captureError directly in routers.
+**IMPORTANT:** tRPC routers use CustomTRPCError for centralized error capture. Do NOT use try-catch or recordError directly in routers.
 
 #### Pattern 1: Database Query
 
@@ -863,7 +881,7 @@ Use these severity levels consistently:
 
 ❌ **Don't:**
 - Use try-catch in tRPC routers (creates double-capture)
-- Use captureError directly in tRPC routers (use toCustomTRPCError)
+- Use recordError directly in tRPC routers (use toCustomTRPCError)
 - Wrap business logic errors with CustomTRPCError (use standard TRPCError)
 - Forget to add .catch() to async operations
 
@@ -991,5 +1009,5 @@ Runs on a fresh runner using `RELEASE_TOKEN` (PAT) to push past branch protectio
 
 ---
 
-**Last Updated**: 2026-05-10
+**Last Updated**: 2026-05-20
 **For detailed architecture explanation**: See `ARCHITECTURE.md`

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -78,7 +78,7 @@ apps/server/src/
 ├── utils.ts               # Helper functions
 ├── websocket.constants.ts # Reconnect delay, idle timeout
 └── utils/
-    └── app-error.ts       # OTEL wrappers (captureError, addBreadcrumb)
+    └── app-error.ts       # OTEL facade (recordError, recordEvent)
 
 packages/shared/src/       # imported as `@fpp/shared`
 ├── room.actions.ts        # TypeBox action schemas + Action union (types only)
@@ -235,46 +235,54 @@ await fetch(`${process.env.TRPC_URL}/room.trackFlip`, {
 
 ## Error Handling
 
-fpp-server emits OpenTelemetry traces and log records to ClickStack/HyperDX. The `app-error.ts` wrapper records exceptions on the active span and emits correlated log records — same public API across all three services.
+fpp-server emits OpenTelemetry traces, log records **and metrics** to
+ClickStack/HyperDX. **Observability v2** added metrics + log-based events + a
+typed taxonomy — see `docs/otel-migration/05-observability-v2.md` and
+`.claude/rules/observability.md`. The facade uses OTEL-native verbs (clean
+break, no Sentry-era aliases). fpp-server is the **authoritative owner of all
+metrics**.
 
-### Error Capture Helpers
+### Telemetry Helpers
 
 **Import:**
 
 ```typescript
-import { addBreadcrumb, captureError, captureMessage } from './utils/app-error';
+import { recordError, recordEvent } from './utils/app-error';
+import { metrics } from './telemetry';
+import { ATTR, EVENT } from '@fpp/shared/telemetry';
 ```
 
 **Usage:**
 
 ```typescript
-// System errors
-captureError(
+// Exceptions
+recordError(
   error as Error,
   {
     component: 'messageHandler',
-    action: 'selectEstimation',
+    action: 'estimate',
     extra: { roomId, userId },
   },
   'high',
 );
 
-// Informational messages
-captureMessage(
-  'Unknown action received',
-  {
-    component: 'messageHandler',
-    action: 'routeAction',
-    extra: { action: message.action },
-  },
-  'medium',
-);
-
-// Breadcrumbs (lifecycle events)
-addBreadcrumb('WebSocket connection opened', 'websocket', {
-  roomId,
-  userId,
+// Log-based domain events — emitted at the state-mutation chokepoint in
+// room.entity / room.state (NOT the handler), so timer/cron paths are covered.
+recordEvent(EVENT.VOTE_CAST, {
+  [ATTR.ROOM_ID]: this.id,
+  [ATTR.USER_ID]: userId,
+  [ATTR.VOTE_VALUE]: estimation,
 });
+
+// Metrics — typed handles from telemetry.ts (never a raw meter). No room.id /
+// user.id on a metric. instrumentAction owns the action RED metrics.
+metrics.voteCast.add(1, { [ATTR.VOTE_VALUE]: estimation });
+
+// Operator narration → Pino (stdout), not OTEL.
+log.warn(
+  { component: 'messageHandler', action: 'routeAction' },
+  'Unknown action',
+);
 ```
 
 ### Error Severity Guidelines
@@ -289,9 +297,9 @@ addBreadcrumb('WebSocket connection opened', 'websocket', {
 ### What NOT to Capture
 
 - Room/user not found (stale state, expected)
-- Invalid message format (validation, expected)
+- Invalid message format (validation, expected) → Pino warning, not OTEL
 - Normal WebSocket closes (1000, 1001, 1005, 1006)
-- Connection errors (sampled at 10%)
+- Abnormal closes → the `ws.disconnected` event, not an error
 
 ### Centralized Capture Points
 
@@ -301,9 +309,9 @@ addBreadcrumb('WebSocket connection opened', 'websocket', {
 
 ### Privacy & Performance
 
-- **PII removed:** email, IP, geo, headers (beforeSend)
-- **Sampling:** Connection errors sampled at 10%
-- **Performance tracing:** 10% in production
+- **PII removed:** users are anonymous nanoid(21) — no email/IP/auth attached.
+- **Sampling:** 100% traces (full fidelity at this scale). Metrics aggregated;
+  events 100%. Revisit head/tail sampling only if span volume becomes a cost.
 - **Development:** OTEL ships to local ClickStack on `http://localhost:4319` (unauthed)
 
 ### Graceful Degradation
@@ -497,9 +505,10 @@ bun run typecheck
 ### Environment Variables
 
 ```bash
-TRPC_URL=http://localhost:3001/api/trpc  # Next.js tRPC endpoint
-FPP_SERVER_SECRET=secret-token           # Auth for callbacks
-SENTRY_DSN=https://...                   # Error tracking
+TRPC_URL=http://localhost:3001/api/trpc          # Next.js tRPC endpoint
+FPP_SERVER_SECRET=secret-token                   # Auth for callbacks
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4319 # ClickStack OTLP (traces/logs/metrics)
+OTEL_SERVICE_NAME=fpp-server
 NODE_ENV=development
 ```
 
@@ -572,6 +581,6 @@ Use Context7 MCP as a reference for documentation:
 
 ---
 
-**Last Updated**: 2025-12-27
+**Last Updated**: 2026-05-20
 **For architecture overview**: See `/ARCHITECTURE.md`
 **For client integration**: See `/CLAUDE.md` (root)

--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -47,6 +47,37 @@ export default tseslint.config(
           },
         },
       ],
+
+      // OTEL: telemetry primitives must only be touched inside telemetry.ts and
+      // the app-error facade. Domain code goes through recordError / recordEvent
+      // and the typed `metrics` handles — never the raw logs/metrics APIs.
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@opentelemetry/api-logs',
+              importNames: ['logs'],
+              message:
+                'Use recordError() / recordEvent() from utils/app-error instead of emitting OTEL logs directly.',
+            },
+            {
+              name: '@opentelemetry/api',
+              importNames: ['metrics'],
+              message:
+                'Create meters/instruments only in telemetry.ts; consume the typed `metrics` handles it exports.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  // Exception: the telemetry bootstrap + facade need direct OTEL access.
+  {
+    name: 'otel-exceptions',
+    files: ['src/telemetry.ts', 'src/utils/app-error.ts'],
+    rules: {
+      'no-restricted-imports': 'off',
     },
   },
 );

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -98,7 +98,7 @@ export default defineConfig([
         },
       ],
 
-      // OTEL: Enforce captureError wrapper instead of direct OTEL/HyperDX calls
+      // OTEL: Enforce the app-error facade instead of direct OTEL/HyperDX calls
       'no-restricted-imports': [
         'error',
         {
@@ -107,12 +107,18 @@ export default defineConfig([
               name: '@opentelemetry/api-logs',
               importNames: ['logs'],
               message:
-                'Use captureError(), captureMessage(), or addBreadcrumb() from fpp/utils/app-error instead of emitting OTEL logs directly.',
+                'Use recordError() or recordEvent() from fpp/utils/app-error instead of emitting OTEL logs directly.',
+            },
+            {
+              name: '@opentelemetry/api',
+              importNames: ['metrics'],
+              message:
+                'The browser emits events, not metrics — the authoritative server owns all metrics. Do not create meters here.',
             },
             {
               name: '@hyperdx/browser',
               message:
-                'Use captureError() from fpp/utils/app-error instead of @hyperdx/browser directly. Init lives in instrumentation-client.ts.',
+                'Use recordError() from fpp/utils/app-error instead of @hyperdx/browser directly. Init lives in instrumentation-client.ts.',
             },
           ],
         },

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -14,6 +14,9 @@ HyperDX.init({
   apiKey: env.NEXT_PUBLIC_HYPERDX_API_KEY,
   url: env.NEXT_PUBLIC_HYPERDX_URL,
   service: 'free-planning-poker',
+  // Groups the three fpp services as one app in HyperDX (parity with the
+  // server/analytics resource attribute).
+  otelResourceAttributes: { 'service.namespace': 'free-planning-poker' },
   tracePropagationTargets: [
     /\/api\/trpc/,
     // Escape regex metacharacters from the runtime URL so e.g. dots only

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -16,6 +16,8 @@ export async function register() {
 
   const resource = resourceFromAttributes({
     'service.name': process.env.OTEL_SERVICE_NAME ?? 'free-planning-poker',
+    // Groups the three fpp services as one app in HyperDX.
+    'service.namespace': 'free-planning-poker',
     'service.version': process.env.VERCEL_GIT_COMMIT_SHA ?? 'local',
     'deployment.environment': process.env.NODE_ENV ?? 'development',
   });
@@ -23,6 +25,7 @@ export async function register() {
   registerOTel({
     serviceName: process.env.OTEL_SERVICE_NAME ?? 'free-planning-poker',
     attributes: {
+      'service.namespace': 'free-planning-poker',
       'service.version': process.env.VERCEL_GIT_COMMIT_SHA ?? 'local',
       'deployment.environment': process.env.NODE_ENV ?? 'development',
     },


### PR DESCRIPTION
## Observability v2 — Phase 6 (enforcement + docs)

Locks in the taxonomy with lint + project rules + docs, and finishes the `service.namespace` rollout.

### ESLint (backstop to the typed registry)
- **apps/server** gains a `no-restricted-imports` block (it had none): bans `logs` (`@opentelemetry/api-logs`) and `metrics` (`@opentelemetry/api`) outside `telemetry.ts` / `utils/app-error.ts`.
- **apps/web** adds the `metrics` ban (the browser emits events, not metrics) alongside the existing `logs` + `@hyperdx/browser` bans.

### Project rule
- New `.claude/rules/observability.md`, `paths:`-scoped over the telemetry/facade/handler files across all three services. Codifies the §3 signal-decision matrix, §4 naming, the chokepoint + observable-gauge + clean-break rules, and the §7-8 taxonomy. Points at the spec as source of truth.

### Docs
- **Root CLAUDE.md** error-handling section: re-pointed to `05-observability-v2.md` + the new rule; documents `recordError`/`recordEvent`/`metrics`; `captureMessage`/`addBreadcrumb` removed; "Breadcrumb Guidelines" → event guidance. Date bumped.
- **apps/server/CLAUDE.md**: purged stale Sentry-era guidance (`SENTRY_DSN` env var, "Connection errors sampled at 10%", "Performance tracing: 10% in production") → 100% sampling + OTEL env vars; refreshed the telemetry-helpers section to the new verbs + typed metrics.

### `service.namespace` (constraint #9, all surfaces)
- web `instrumentation.ts` (traces via `registerOTel` + logs via `LoggerProvider`) and `instrumentation-client.ts` (browser RUM via `otelResourceAttributes`) now set `service.namespace=free-planning-poker`, matching the server (P2) and analytics (P5) resources.

### Verification
`bun run validate` green for server + web (format, lint, typecheck, build). The new bans don't misfire — all telemetry primitive imports already live in the allowlisted facade/telemetry/instrumentation files.

### Next
P7: SDK Views per-metric attribute allowlist (drops a stray `room.id`/`user.id` before export), validate cardinality bounded.