### PR TITLE
feat: per-metric attribute allowlist via SDK Views — Observability v2 P7

### DIFF
--- a/apps/server/src/telemetry.ts
+++ b/apps/server/src/telemetry.ts
@@ -20,11 +20,13 @@ import {
   LoggerProvider,
 } from '@opentelemetry/sdk-logs';
 import {
+  type ViewOptions,
+  createAllowListAttributesProcessor,
   MeterProvider,
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { METRIC } from '@fpp/shared/telemetry';
+import { ATTR, METRIC } from '@fpp/shared/telemetry';
 
 const SERVICE_NAME = process.env.OTEL_SERVICE_NAME ?? 'fpp-server';
 const SERVICE_VERSION = process.env.OTEL_SERVICE_VERSION ?? 'local';
@@ -61,8 +63,47 @@ logs.setGlobalLoggerProvider(loggerProvider);
 // THIS provider's meter (not the global) so they always export via our reader
 // regardless of what touches the global meter provider. fpp-server is the
 // authoritative owner of room state, so it owns all metrics (spec §5/§8).
+// Per-metric attribute allowlist (spec §13). A View drops any attribute not on
+// the list BEFORE export, so a stray room.id / user.id passed at a record site
+// can never reach a metric series — enforcement, not just convention. Empty
+// allowlist = the gauges/totals that carry no labels.
+const allow = (...keys: string[]) => createAllowListAttributesProcessor(keys);
+
+const metricViews: ViewOptions[] = [
+  { instrumentName: METRIC.USER_ACTIVE.name, attributesProcessors: [allow()] },
+  { instrumentName: METRIC.ROOM_ACTIVE.name, attributesProcessors: [allow()] },
+  {
+    instrumentName: METRIC.CONNECTION_ACTIVE.name,
+    attributesProcessors: [allow()],
+  },
+  {
+    instrumentName: METRIC.ACTION_COUNT.name,
+    attributesProcessors: [
+      allow(ATTR.ACTION_TYPE, ATTR.OUTCOME, ATTR.ERROR_TYPE),
+    ],
+  },
+  {
+    instrumentName: METRIC.ACTION_DURATION.name,
+    attributesProcessors: [allow(ATTR.ACTION_TYPE)],
+  },
+  {
+    instrumentName: METRIC.VOTE_CAST.name,
+    attributesProcessors: [allow(ATTR.VOTE_VALUE)],
+  },
+  {
+    instrumentName: METRIC.ROUND_FLIPPED.name,
+    attributesProcessors: [allow(ATTR.FLIP_TRIGGER, ATTR.ROUND_CONSENSUS)],
+  },
+  { instrumentName: METRIC.ROOM_CREATED.name, attributesProcessors: [allow()] },
+  {
+    instrumentName: METRIC.ROOM_CLOSED.name,
+    attributesProcessors: [allow(ATTR.CLOSE_REASON)],
+  },
+];
+
 const meterProvider = new MeterProvider({
   resource,
+  views: metricViews,
   readers: [
     new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({ url: `${BASE_URL}/v1/metrics` }),


### PR DESCRIPTION
## Observability v2 — Phase 7 (final): SDK Views

Closes the cardinality budget. Each fpp-server metric gets a **View with an explicit attribute allowlist**, so a stray `room.id` / `user.id` passed at a record site is dropped *before* export — enforcement, not just convention (spec §13). This makes "no metric carries `room.id`/`user.id`" structurally guaranteed, not review-dependent.

### API note
`@opentelemetry/sdk-metrics` 2.x replaced the `View` class / `FilteringAttributesProcessor` (from the older docs) with plain `ViewOptions[]` on `MeterProvider({ views })` + `createAllowListAttributesProcessor(keys)`. Verified against the installed 2.1.0.

### Allowlists (per §8)
| Metric | Allowed attributes |
|-|-|
| `fpp.user.active` / `fpp.room.active` / `fpp.ws.connections.active` | — (none) |
| `fpp.room.created` | — (none) |
| `fpp.room.closed` | `close.reason` |
| `fpp.action.count` | `action.type`, `outcome`, `error.type` |
| `fpp.action.duration` | `action.type` |
| `fpp.vote.cast` | `vote.value` |
| `fpp.round.flipped` | `flip.trigger`, `round.consensus` |

Analytics metrics are bounded by construction (`endpoint` = route template, `outcome`, `error.type` = HTTP status) and carry no `room.id`/`user.id`, so they need no View.

### Verification
`bun run validate:server` green. Decisive enforcement test against local ClickStack: with `room.id` + `user.id` **deliberately injected** onto the `fpp.vote.cast` call, the View dropped both and kept only `vote.value` (=13). The injection was reverted before commit.

---

This is the **final phase** of [Observability v2](docs/otel-migration/05-observability-v2.md). All §17 success criteria are met except the deferred HyperDX dashboards (explicitly out of scope — data collection only).