### PR TITLE
feat: edge-derived geo + honest GDPR imprint, drop ip-api.com

### DIFF
--- a/apps/web/src/components/index/privacy.tsx
+++ b/apps/web/src/components/index/privacy.tsx
@@ -28,8 +28,8 @@ export const Privacy = () => {
         Protecting Your Privacy
       </Title>
       <Title order={3} className="mt-5 font-normal opacity-70">
-        Our policies are clear: no personal data stored, no cookies used, fully
-        GDPR compliant.
+        Our approach is clear: no cookies, no third-party tracking, your IP is
+        never stored — built around GDPR principles.
       </Title>
       <Group justify="center" className="mt-7">
         <Link href={'/imprint'}>
@@ -56,7 +56,7 @@ export const Privacy = () => {
         {[
           'No cookies',
           'GDPR Compliant',
-          'No Personal Data',
+          'No IP Stored',
           'Anonymized Analytics',
           'Open Source',
         ].map((feature, index) => (

--- a/apps/web/src/pages/api/track-page-view.ts
+++ b/apps/web/src/pages/api/track-page-view.ts
@@ -15,6 +15,7 @@ import {
 } from 'fpp/constants/error.constant';
 
 import { recordError } from 'fpp/utils/app-error';
+import { logger } from 'fpp/utils/logger';
 import { validateNanoId } from 'fpp/utils/validate-nano-id.util';
 
 import db from 'fpp/server/db/db';
@@ -54,7 +55,7 @@ const TrackPageView = async (req: NextApiRequest, res: NextApiResponse) => {
     )[0];
 
     if (!userExists) {
-      const userPayload = await getUserPayload(req);
+      const userPayload = getUserPayload(req);
       await db.insert(users).values({
         id: userId,
         ...userPayload,
@@ -93,74 +94,67 @@ const TrackPageView = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export const getUserPayload = async (req: NextApiRequest) => {
+const headerValue = (req: NextApiRequest, name: string): string | null => {
+  const value = req.headers[name];
+  return Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
+};
+
+// decodeURIComponent throws on malformed input — fall back to the raw value.
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+export const getUserPayload = (req: NextApiRequest) => {
   const ua = userAgentFromString(req.headers['user-agent']);
 
-  const geo: {
-    country: string | null;
-    region: string | null;
-    city: string | null;
-  } = {
-    country: null,
-    region: null,
-    city: null,
-  };
+  // Approximate geolocation comes from Vercel's edge headers: the visitor's IP
+  // is resolved to a coarse location at the edge and is NOT forwarded to any
+  // third party and NOT stored. This is what the privacy policy (imprint.tsx)
+  // promises — keep them in sync.
+  const country = headerValue(req, 'x-vercel-ip-country');
+  const region = headerValue(req, 'x-vercel-ip-country-region');
+  const cityRaw = headerValue(req, 'x-vercel-ip-city'); // RFC3986-encoded
+  const city = cityRaw ? safeDecode(cityRaw) : null;
 
-  let ip =
-    req?.headers['x-forwarded-for'] ??
-    req?.headers['X-Forwarded-For'] ??
-    req?.headers['x-real-ip'] ??
-    req.socket.remoteAddress ??
-    '::1';
-
-  if (ip instanceof Array && ip.length > 0) {
-    ip = ip[0]!;
+  // Fail-open monitor: when the edge geo headers are absent we store no location
+  // rather than calling out to a third-party IP service. This warn log (no IP,
+  // no PII) is how we measure how often that happens — if it stays ~0 in
+  // production the Vercel-edge path is validated and no fallback is needed.
+  if (!country && process.env.NODE_ENV === 'production') {
+    logger.warn(
+      { component: 'getUserPayload' },
+      'geo headers absent — stored null location (no third-party fallback)',
+    );
   }
 
-  if (ip.includes(',') && ip instanceof String) {
-    ip = ip.split(',')[0]!;
-  }
-
-  if (ip !== '::1') {
-    try {
-      const geoResponse = await fetch(`http://ip-api.com/json/${ip as string}`);
-
-      if (!geoResponse.ok) {
-        throw new Error(`Geo API responded with status: ${geoResponse.status}`);
-      }
-
-      const geoData = (await geoResponse.json()) as {
-        countryCode: string;
-        region: string;
-        city: string;
-      };
-      console.log('geoData', geoData);
-      geo.country = geoData.countryCode;
-      geo.region = geoData.region;
-      geo.city = geoData.city;
-    } catch (error) {
-      // Geo fetch failure is non-critical, but we should track it
-      recordError(
-        error instanceof Error ? error : new Error('Failed to fetch geo data'),
-        {
-          component: 'getUserPayload',
-          action: 'fetchGeoData',
-          extra: {
-            ip: typeof ip === 'string' ? ip.substring(0, 20) : 'unknown',
-          },
-        },
-        'low',
-      );
-    }
-  }
+  /*
+   * FALLBACK DISABLED (2026-05-20). Geolocation previously resolved by sending
+   * the visitor's full IP to ip-api.com over plain HTTP — a third-country
+   * transfer of personal data, unencrypted in transit. Replaced by the Vercel
+   * edge headers above. Left here, commented out, until the "geo headers
+   * absent" warn log confirms the edge path covers production traffic. If a
+   * fallback is ever reintroduced it MUST use an HTTPS provider and be
+   * disclosed in the privacy policy as a processor + third-country transfer.
+   *
+   * let ip =
+   *   req?.headers['x-forwarded-for'] ??
+   *   req?.headers['x-real-ip'] ??
+   *   req.socket.remoteAddress ?? '::1';
+   * const geoResponse = await fetch(`https://<https-geo-provider>/json/${ip}`);
+   * const geoData = await geoResponse.json();
+   */
 
   return {
     browser: ua?.browser?.name ?? null,
     device: ua.isBot ? 'bot' : (ua?.device?.type ?? 'desktop'),
     os: ua?.os?.name ?? null,
-    city: geo.city ?? null,
-    country: geo.country ?? null,
-    region: geo.region ?? null,
+    city,
+    country,
+    region,
   };
 };
 

--- a/apps/web/src/pages/imprint.tsx
+++ b/apps/web/src/pages/imprint.tsx
@@ -24,17 +24,21 @@ const Imprint: NextPage = () => {
         <div className="container max-w-[1200px] gap-12 px-4 pb-12 pt-8 md:flex">
           <div className="mb-20 md:mb-0 md:min-w-[250px]">
             <h2>Imprint</h2>
-            <h4>Service Provider</h4>
+            <h4>Operated by</h4>
             Johannes Krumm
             <br />
-            Based in Munich, Germany
+            Munich, Germany
             <br />
             <br />
-            <h4>Contact Information</h4>
-            For direct communication,
+            Free Planning Poker is a free, open-source, non-commercial project
+            run by a private individual.
             <br />
-            please visit our contact page <br />
-            and fill out the form provided.
+            <br />
+            <h4>Contact</h4>
+            For privacy reasons, I do not publish a private postal address or
+            email address here. Please use the contact form to reach me — it
+            goes straight to my inbox. I read every message and respond to all
+            genuine enquiries, including data-protection requests.
             <br />
             <br />
             <Link href="/contact">
@@ -46,149 +50,194 @@ const Imprint: NextPage = () => {
           <div>
             <h2>Privacy Policy</h2>
             <h4>Summary (TL;DR)</h4>
-            We are highly committed to protecting your privacy. We collect
-            anonymized website usage analytics to improve our services and
-            ensure compliance with the General Data Protection Regulation
-            (GDPR). We do not use cookies or store any personally identifiable
-            information (PII). Any data collected by us or third-party systems
-            is scrubbed, encrypted, and anonymized. Detailed policies are
-            provided below.
-            <br />
-            As an open-source project, we are transparent about our practices
-            and welcome any questions or concerns. Please use our contact form
-            to reach out. We are happy to provide further information.
-            <br />
-            <br />
-            <h4>Detailed Privacy Policy</h4>
-            We collect <strong>anonymized website usage analytics</strong> to
-            enhance our services and user experience, ensuring our full
-            compliance with the GDPR, without employing cookies or other
-            continuous tracking technologies.
-            <br />
-            The data we accumulate includes{' '}
-            <strong>generic device details</strong> (such as type, OS, browser),
-            approximate geolocation (incorporating country, city, region), and a
-            randomized unique session ID saved in your local storage. We use a
-            professional IP address API service (ip-api.com) to procure this
-            anonymized geolocation data. You may refer to{' '}
-            <a
-              href="https://ip-api.com/docs/legal"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              ip-api.com privacy policy
-            </a>
-            . This data acquisition service is entirely GDPR compliant, ensuring
-            the encryption of data in transit. Neither us nor ip-api.com process
-            or store any personally identifiable information or more specially
-            your IP address.
-            <br />
-            The <strong>unique session ID</strong> enables us to monitor your
-            page visits and certain activities on our site, such as your
-            entering a room and final vote, helping us to understand user
-            behaviors and preferences.
-            {/* eslint-disable-next-line react/no-unescaped-entities */}
-            This data collection operates under the 'legitimate interests'
-            lawful basis as per GDPR Article 6(1)(f). As we only deal with
-            anonymized data and perform no processing of personally identifiable
-            information, there is no need for prior consent. We maintain our
-            unwavering commitment to your privacy and strictly adhere to data
-            protection principles.
+            Free Planning Poker is built to be private by design.
+            <strong>
+              {' '}
+              No cookies. No third-party advertising or tracking.
+            </strong>{' '}
+            Your IP address is never sent to any third party and is never
+            stored. We run our own analytics and error monitoring on our own
+            servers in Germany — no Google Analytics, no external trackers, no
+            advertising networks. The little data we keep (coarse location,
+            browser type, anonymous usage) is tied only to a random ID generated
+            in your browser, never to your name, email, or IP address. Because
+            we set no non-essential cookies and load no third-party trackers,
+            you see no cookie banner.
             <br />
             <br />
-            Our service employs a custom-built, open-source{' '}
-            <strong>WebSocket server</strong> implemented using Bun and ElysiaJS
-            to enable real-time communication. This server, part of the
-            free-planning-poker.com project, is completely stateless and does
-            not track or store any user information. Its sole purpose is to
-            share the current state of voting among connected users. You can
-            view the code and contribute to its development on our{' '}
+            As an open-source project we are transparent about how this works.
+            The full source code is on{' '}
             <a
               href="https://github.com/jkrumm/free-planning-poker"
               target="_blank"
               rel="noopener noreferrer"
             >
-              GitHub repository
+              GitHub
             </a>
-            . It is running on a Hetzner VPS located in Nuremberg, Germany.
+            , and you are welcome to verify any of the claims below. If anything
+            is unclear, please reach out via the contact form.
             <br />
             <br />
-            We utilize a <strong>self-hosted OpenTelemetry stack</strong>{' '}
-            (ClickStack / HyperDX) for error tracking and distributed tracing to
-            improve our services. All telemetry data stays on our Hetzner VPS in
-            Nuremberg, Germany — no third-party processors are involved. Our
-            instrumentation does not send personally identifiable information:
-            request headers, IP addresses, and email addresses are excluded from
-            spans and log records to maintain our commitment to GDPR compliance.
+            <h4>Controller</h4>
+            The controller responsible for data processing on this website is
+            Johannes Krumm, Munich, Germany (see the Imprint). The fastest way
+            to contact me about privacy is the contact form.
             <br />
             <br />
-            Personal details offered through our <strong>
-              contact form
-            </strong>{' '}
-            (name and email), in agreement with GDPR definitions, are managed
-            with utmost confidentiality and used solely for responding to your
-            inquiries. We use resend.com as a third-party service to forward
-            these emails securely to our inbox. Resend.com is fully GDPR
-            compliant and does not store any personal data or the information
-            you entered into the contact form fields. You can read more about
-            their privacy practices here:{' '}
+            <h4>What we collect, and why</h4>
+            We process a deliberately small amount of data to understand how the
+            tool is used and to keep it working:
+            <br />
+            <br />
+            <strong>Usage analytics.</strong> For each visit we store generic
+            device details (device type, operating system, browser), a coarse
+            approximate location (country, region, and city), and a random,
+            anonymous ID that is generated in your browser and saved in your
+            local storage. Using that ID we record page views and certain
+            actions (for example entering a room or copying a room link) so we
+            can understand overall usage patterns. This ID is random and is not
+            linked to your name, email, or IP address.
+            <br />
+            <br />
+            <strong>Approximate location.</strong> The country, region, and city
+            are derived from Vercel edge headers at the moment your request
+            arrives. Your IP address is resolved to a coarse location at the
+            edge and is{' '}
+            <strong>
+              never forwarded to a third party and never stored by us
+            </strong>
+            . If the location cannot be determined, we simply store nothing for
+            that field — we do not fall back to any external IP lookup service.
+            <br />
+            <br />
+            <strong>Estimations (votes).</strong> When a voting round is
+            revealed, the individual estimations are saved linked to the random
+            anonymous ID and the room, together with a timestamp, so we can show
+            room history and aggregate statistics. These records are tied to the
+            anonymous ID only — your chosen username is never stored with them,
+            and the data does not identify you.
+            <br />
+            <br />
+            <strong>Contact form.</strong> If you use the contact form, we
+            process the email address you provide (and your name, if you choose
+            to add one) for the sole purpose of answering your message. This is
+            described under Recipients below.
+            <br />
+            <br />
+            <h4>Legal basis</h4>
+            Usage analytics and the operation of the service are based on our
+            legitimate interests in understanding and improving the tool and
+            keeping it secure and reliable (Art. 6(1)(f) GDPR). Because the data
+            is minimal and not directly identifying, this poses a low risk to
+            your privacy. Processing of contact-form data is based on taking
+            steps at your request and answering your enquiry (Art. 6(1)(b) and
+            (f) GDPR).
+            <br />
+            <br />
+            <h4>Cookies and storage on your device</h4>
+            We do not use cookies. We store a small amount of data in your
+            browser local storage: your chosen username and your interface
+            preferences (which are strictly necessary to provide the features
+            you request), and the random anonymous analytics ID described above.
+            We do not use any cross-site, fingerprinting, or advertising
+            technologies. Because we set no non-essential cookies and embed no
+            third-party trackers, no consent banner is required.
+            <br />
+            <br />
+            <h4>Recipients and processors</h4>
+            We keep the number of parties involved to a minimum:
+            <br />
+            <br />
+            <strong>Hosting (frontend / CDN):</strong> the website is served by
+            Vercel Inc. (USA). Vercel processes technical request data and
+            provides the edge geolocation described above, under a data
+            processing agreement and EU Standard Contractual Clauses.
+            <br />
+            <br />
+            <strong>Application servers and database:</strong> our real-time
+            WebSocket server, our database (MariaDB), and our telemetry stack
+            run on a Hetzner VPS located in Nuremberg, Germany. The WebSocket
+            server is stateless and exists only to share the current voting
+            state between connected participants; all transfers are encrypted.
+            <br />
+            <br />
+            <strong>Error monitoring and tracing:</strong> we use a self-hosted
+            OpenTelemetry stack (ClickStack / HyperDX) on the same German VPS —
+            no third-party observability provider is involved. Our
+            instrumentation is configured to exclude personal data such as IP
+            addresses, request headers, and email addresses from spans and log
+            records.
+            <br />
+            <br />
+            <strong>Contact email delivery:</strong> messages from the contact
+            form are first received by our own self-hosted email service in
+            Germany and then delivered to our inbox through Resend (Resend,
+            Inc., USA) acting as a processor under a data processing agreement
+            and EU Standard Contractual Clauses. We do not store contact-form
+            messages in our application database and we do not use them for
+            marketing.{' '}
             <a
               href="https://resend.com/legal/privacy-policy"
               target="_blank"
               rel="noopener noreferrer"
             >
-              Resend.com Privacy Policy
+              Resend privacy policy
             </a>
-            . We will seek your consent prior to using this data for any
-            unrelated purpose.
+            .
             <br />
             <br />
-            Our website runs on a proprietary <strong>database</strong> system
-            hosted on a MariaDB in a Hetzner VPS located in Nuremberg, Germany.
-            To preserve data integrity, all transfers are encrypted. But the use
-            of the database is confined to storing the anonymized website usage
-            analytics and has no connection to specific usernames or individual
-            votes. Whatever information collected in no way contributes to
-            individual profiles.
+            <h4>International transfers</h4>
+            Most processing happens in Germany. Where a processor is located in
+            the USA (Vercel for hosting, Resend for contact email), the transfer
+            is covered by a data processing agreement and EU Standard
+            Contractual Clauses. We do not transfer your IP address abroad for
+            geolocation.
             <br />
             <br />
-            In our service, <strong>usernames</strong> are entirely fictional.
-            They are neither stored nor connected to the website usage
-            analytics. While these names and corresponding votes are accessible
-            upon entry to the room, they are not identifiable. We insist on the
-            avoidance of identifiable information as usernames to ensure GDPR
-            compliance.
+            <h4>Data retention</h4>
+            The WebSocket server is stateless and keeps no data beyond the live
+            session. Anonymous usage analytics and estimation records are kept
+            to observe long-term trends; because they are tied only to a random
+            ID and contain no directly identifying information, we do not
+            routinely delete them. We will delete data on request where feasible
+            (see your rights below). Contact-form messages are kept only as long
+            as needed to handle your enquiry.
             <br />
             <br />
-            <h2>Data Retention</h2>
-            Our Bun WebSocket server is stateless, meaning it does not store any
-            session data. All communications are ephemeral, ensuring that no
-            user information persists beyond the immediate session. Our
-            analytics are fully GDPR compliant and are anonymized in such a
-            {/* eslint-disable-next-line react/no-unescaped-entities */}
-            way that they cannot be linked back to any individual's identity, IP
-            address, email, or username. Therefore, we typically do not aim to
-            delete the analytics data since it is already anonymized and poses
-            no risk to user privacy.
+            <h4>Your rights</h4>
+            Under the GDPR you have the right to access your data, to have it
+            rectified or erased, to restrict or object to its processing, and to
+            data portability, as well as the right to withdraw any consent you
+            have given. Because we do not store directly identifying
+            information, we may be unable to locate data about a specific person
+            without additional information from you; we will nonetheless act on
+            genuine requests, including deleting anonymous data tied to your
+            local storage ID where you can identify it. To exercise any of these
+            rights, please use the contact form.
             <br />
             <br />
-            <h2>User Rights Under GDPR</h2>
-            You have the right to access, rectify, or delete any data we hold
-            about you. Since we do not store any personally identifiable
-            information, we or third-party tools do not hold any data in this
-            regard. However, we are open to deleting even the anonymized data if
-            requested. Please reach out to us using our contact form for such
-            requests.
+            <h4>Right to lodge a complaint</h4>
+            You also have the right to lodge a complaint with a data protection
+            supervisory authority. The authority responsible for us is the
+            Bavarian State Office for Data Protection Supervision (Bayerisches
+            Landesamt für Datenschutzaufsicht, BayLDA), Ansbach, Germany —{' '}
+            <a
+              href="https://www.lda.bayern.de"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              www.lda.bayern.de
+            </a>
+            . You may also contact the supervisory authority of your habitual
+            residence.
             <br />
             <br />
             <h2 id="license">Project License</h2>
             The project is licensed under the GNU Affero General Public License
-            v3.0 (AGPLv3). This license ensures that derivative work will be
-            released under the same license terms, promoting open source sharing
-            and improvements. Users can use, modify, and distribute this
-            software and its source code, provided they adhere to the license
-            terms. You can review the full license terms by clicking the link
-            below.
+            v3.0 (AGPLv3). This license ensures that derivative work is released
+            under the same license terms, promoting open-source sharing and
+            improvement. You can use, modify, and distribute this software and
+            its source code provided you adhere to the license terms.
             <br />
             <br />
             <a
@@ -203,20 +252,16 @@ const Imprint: NextPage = () => {
             <br />
             <br />
             <h2>Donations</h2>
-            The PayPal link offered for contributions is solely an option for
-            those who voluntarily choose to financially support the continued
-            upkeep and development of this tool. Any funds received are
-            acknowledged not as formal, tax-deductible donations, or as a
-            commercial transaction involving an exchange of goods or services.
-            They are considered as supportive contributions aiding in this{' '}
-            {/* eslint-disable-next-line react/no-unescaped-entities */}
-            tool's further development. As such, these arrangements are not
-            governed by German Civil Code (BGB) or Consumer Rights Directive{' '}
-            {/* eslint-disable-next-line react/no-unescaped-entities */}
-            (2011/83/EU). The use of the term "donation" herein is a common
-            terminology in online platforms, and it is important to note its
-            context is not linked with the applicable laws and regulations of
-            formal, registered charity donations.
+            The donation link is purely an option for those who voluntarily
+            choose to financially support the continued upkeep and development
+            of this tool. Any funds received are not formal, tax-deductible
+            donations, nor a commercial transaction involving an exchange of
+            goods or services. They are supportive contributions toward the
+            further development of the tool. As such, these arrangements are not
+            governed by the German Civil Code (BGB) or the Consumer Rights
+            Directive (2011/83/EU). The use of the term donation here is common
+            terminology on online platforms and is not linked to the laws and
+            regulations governing formal, registered charity donations.
             <br />
             <br />
             <a
@@ -228,6 +273,9 @@ const Imprint: NextPage = () => {
                 Donate
               </Button>
             </a>
+            <br />
+            <br />
+            <small>Last updated: 20 May 2026</small>
           </div>
         </div>
       </main>

--- a/apps/web/src/server/api/routers/room.router.ts
+++ b/apps/web/src/server/api/routers/room.router.ts
@@ -148,7 +148,7 @@ export const roomRouter = createTRPCRouter({
 
         if (!validateNanoId(userId)) {
           userId = nanoid();
-          const userPayload = await getUserPayload(req);
+          const userPayload = getUserPayload(req);
           await db
             .insert(users)
             .values({


### PR DESCRIPTION
## Summary
The imprint/privacy page made several claims the code contradicted (a real problem, since false privacy claims are themselves a liability) and was missing mandatory GDPR Art. 13 disclosures. At the same time, visitor geolocation sent the full IP to ip-api.com over plain HTTP — an unencrypted third-country transfer of personal data. This makes the claims true by fixing the code, and brings the privacy policy in line with what the app actually does.

## What Changed
- **Geolocation now resolved at the Vercel edge** (`x-vercel-ip-country/-country-region/-city`) instead of POSTing the IP to ip-api.com. The visitor's IP no longer leaves the edge and never reaches a third-country processor. On a header miss we store `null` (no external fallback) and emit a prod-only `geo headers absent` warn log as a monitor — if it stays ~0, the edge path is validated.
- **Stopped leaking PII into telemetry**: removed the truncated IP from the OTEL error context and a leftover `console.log`.
- **Imprint/privacy rewritten to be truthful**: corrected the false ip-api "encrypted / IP not processed" wording, the "votes not stored" claim (individual estimations are stored against the anonymous id), and the Resend "stores nothing" overclaim.
- **Added missing GDPR Art. 13 items**: controller, per-purpose legal basis, processor list, international-transfer disclosure, retention, full data-subject rights, and the right to lodge a complaint (BayLDA). Added an honest no-cookie-banner rationale (§25 TDDDG).
- **Homepage privacy copy** softened from "no personal data stored / fully GDPR compliant" to verifiable claims (no cookies, no third-party tracking, IP never stored).

## Technical Notes
- The imprint **deliberately omits a postal address and contact email** (contact form only). This is a documented, owner-accepted DDG risk for personal-privacy reasons — the page makes no false DDG-compliance claim and will gain an address + email alias later. GDPR Art. 13 is satisfied via name + contact form.
- `getUserPayload` is now synchronous (no network call); its two call sites were updated.
- ip-api fallback is left commented in `track-page-view.ts` with a dated note; if ever reinstated it must be HTTPS + disclosed.
- No format/region data regression: the `region` column already stored short codes (ip-api `region` = code, e.g. `BY`), matching Vercel's ISO region codes.

## Testing
- [x] Code quality validation passed (format + lint + types via lefthook pre-commit)
- [ ] Verify `/imprint` renders correctly (layout, links, contact button)
- [ ] After deploy: confirm geo fields populate on Vercel and check HyperDX for `geo headers absent` frequency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced privacy: IP addresses are no longer stored or processed by the application.

* **Documentation**
  * Updated Privacy Policy and Imprint pages with revised terms and contact information.
  * Added last updated timestamp to policy documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jkrumm/free-planning-poker/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->