### PR TITLE
fix: address SonarCloud security hotspots

### DIFF
--- a/apps/web/src/components/index/form.tsx
+++ b/apps/web/src/components/index/form.tsx
@@ -346,11 +346,10 @@ export function AnimatedNumber({
   delay?: number;
 }) {
   const spring = useSpring(value, { mass: 0.8, stiffness: 75, damping: 15 });
-  // Use space separator (ISO 31-0 standard) - neutral for all locales
+  // Use space separator (ISO 31-0 standard) - neutral for all locales.
+  // toLocaleString + split/join avoids a backtracking lookahead regex.
   const display = useTransform(spring, (current) =>
-    Math.round(current)
-      .toString()
-      .replace(/\B(?=(\d{3})+(?!\d))/g, ' '),
+    Math.round(current).toLocaleString('en-US').split(',').join(' '),
   );
 
   useEffect(() => {

--- a/fpp-analytics/Dockerfile
+++ b/fpp-analytics/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && groupadd --system app && useradd --system --gid app --home-dir /app app
 
-COPY --from=builder --chown=app:app /app /app
+COPY --from=builder /app /app
 
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \

--- a/fpp-analytics/update_readmodel.py
+++ b/fpp-analytics/update_readmodel.py
@@ -39,10 +39,10 @@ UPTIMEKUMA_PUSH_URL = os.getenv("UPTIMEKUMA_PUSH_URL")
 #
 # DB_SSL=true forces a TLS handshake — required when MariaDB is started with
 # --require-secure-transport=ON, which is the case on the VPS. DB_SSL_VERIFY=false
-# skips cert+hostname verification, which is what we want when connecting to
-# the internal `mariadb` hostname (the wildcard cert's CN is *.jkrumm.com and
-# won't match). For external connections through fpp-db.jkrumm.com we'd flip
-# DB_SSL_VERIFY back to true.
+# keeps cert-chain validation but skips only the hostname check — needed when
+# connecting to the internal `mariadb` hostname (the wildcard cert's CN is
+# *.jkrumm.com and won't match). For external connections through
+# fpp-db.jkrumm.com we'd flip DB_SSL_VERIFY back to true (full verification).
 DB_CONFIG: dict[str, Any] = {
     "host": os.getenv("DB_HOST", "mariadb"),
     "port": int(os.getenv("DB_PORT", "3306")),
@@ -57,8 +57,11 @@ if os.getenv("DB_SSL", "false").lower() == "true":
 
     ctx = ssl_module.create_default_context()
     if os.getenv("DB_SSL_VERIFY", "true").lower() == "false":
+        # Validate the cert chain (CERT_REQUIRED, a publicly-trusted LE wildcard)
+        # so a forged cert can't MITM the connection, but skip the hostname check
+        # since the internal `mariadb` host won't match the wildcard SAN.
         ctx.check_hostname = False
-        ctx.verify_mode = ssl_module.CERT_NONE
+        ctx.verify_mode = ssl_module.CERT_REQUIRED
     DB_CONFIG["ssl"] = ctx
 
 # Table definitions: {table_name: sync_column}


### PR DESCRIPTION
Addresses SonarCloud security hotspots.

## Changes

- **Analytics SSL (`update_readmodel.py`)** — when `DB_SSL_VERIFY=false`, switch `CERT_NONE` → `CERT_REQUIRED` + `check_hostname=False`. The internal `mariadb` TLS connection now validates the (publicly-trusted Let's Encrypt) cert chain — blocking a forged-cert MITM — while still skipping only the hostname check the `*.free-planning-poker.com` wildcard can't satisfy for the `mariadb` host.
- **Analytics Dockerfile** — drop `--chown=app:app` on the builder COPY so the venv/code are root-owned and read-only to the `app` runtime user (the process can't rewrite its own code). `/app/data` is chowned writable separately.
- **`AnimatedNumber` (web)** — replace the backtracking lookahead thousands-separator regex with a linear `toLocaleString('en-US').split(',').join(' ')`. No behavior change.

## Resolved vs. accepted

| Hotspot | Status |
|-|-|
| SSL cert validation | Resolved (chain now validated) |
| SSL hostname verification | Accepted by design — internal host can't match wildcard; TLS + chain validation remain |
| Dockerfile copy write perms | Resolved |
| Thousands-separator ReDoS | Resolved (linear, and input was bounded non-user data anyway) |
| `uv sync` without `--no-build` (×2) | Accepted — lockfile pins versions+hashes; `--no-build` risks breaking the Python 3.14 build |

## Verification note

The SSL change exercises the prod sync path and can't be proven by local validation — it'll be confirmed on the next `fpp-analytics-updater` run after deploy (UptimeKuma heartbeat + OTEL).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved number display formatting with consistent spacing in numeric values.

* **Chores**
  * Enhanced database security configuration with stricter TLS certificate validation.
  * Updated container build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jkrumm/free-planning-poker/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->