### PR TITLE
refactor: analytics dev secret injection via secrets-run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ cython_debug/
 
 # Auto Claude data directory
 .auto-claude/
+fpp-server/.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ bun run dev:all
 # Or individually
 bun run dev                        # Next.js only (port 7720)
 bun run --filter=@fpp/server dev   # WebSocket server only (port 7721)
-cd fpp-analytics && op run --account tkrumm --env-file=.env.tpl -- uv run uvicorn main:app --reload --port 7722
+cd fpp-analytics && secrets-run run --env-file=.env.tpl -- uv run uvicorn main:app --reload --port 7722
 ```
 
 **First-time analytics setup:** `cd fpp-analytics && uv run python update_readmodel.py` once to generate the Parquet files.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dev:all:logdy": "./scripts/kill-ports.sh 7723 7724 7725 7726 && logdy socket --port 7723 7724 7725 7726 --config logdy.config.json",
     "dev:all:nextjs": "sleep 2 && bun run --filter=@fpp/web dev 2>&1 | logdy forward 7724",
     "dev:all:server": "sleep 2 && bun run --filter=@fpp/server dev 2>&1 | logdy forward 7725",
-    "dev:all:analytics": "sleep 2 && ./scripts/kill-ports.sh 7722 && cd fpp-analytics && op run --account tkrumm --env-file=.env.tpl -- uv run uvicorn main:app --reload --port 7722 2>&1 | logdy forward 7726",
+    "dev:all:analytics": "sleep 2 && ./scripts/kill-ports.sh 7722 && cd fpp-analytics && secrets-run run --env-file=.env.tpl -- uv run uvicorn main:app --reload --port 7722 2>&1 | logdy forward 7726",
     "start": "bun run --filter=@fpp/web start",
     "lint": "bun run --filter=@fpp/web lint",
     "lint:fix": "bun run --filter=@fpp/web lint:fix",


### PR DESCRIPTION
## What
Swap `dev:all:analytics` (and its README command) from `op run --account tkrumm --env-file=.env.tpl` to `secrets-run run --env-file=.env.tpl`.

## Why
Part of the headless op-over-cache rollout. `secrets-run` is a faithful `op` drop-in: on the MacBook (op backend) it passes straight through to `op run --account tkrumm --env-file=… --` (identical behavior); on the Mac mini it resolves from the age-encrypted cache — same tpl, same interface, per-machine backend. The `--account tkrumm` flag is dropped; the shim supplies it.

## Scope
Analytics only. The `apps/web` / `apps/server` `op run` scripts are intentionally left for a later pass — their `op://vps/fpp/*` / `op://vps/mariadb/*` prod-matching refs carry separate tiering decisions (which refs may enter the mini's headless cache).

## Validation
- `secrets-run`'s op-backend branch is a literal `op run` passthrough, so behavior on the MacBook is unchanged by construction.
- On the mini, `secrets-run run --env-file=fpp-analytics/.env.tpl` parses cleanly and reports `op://vps/fpp/ANALYTICS_SECRET_TOKEN` as the one ref to seed (expected — not yet in `headless.refs`).
- `bun run dev:all:analytics` end-to-end to be confirmed on the dev machine (op backend / after seeding).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the analytics service quick-start instructions to use the current secrets-based startup command.

* **Chores**
  * Updated the all-services development command to launch analytics with the new secrets workflow.
  * Added local Claude settings to the ignored files list to prevent accidental commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->