### PR TITLE
refactor: web + server dev secret injection via secrets-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ Free Planning Poker is a Next.js application using the **Pages Router** (not App
 
 ## Build & Development Commands
 
-**IMPORTANT**: Always use `SKIP_ENV_VALIDATION=1` for local Next.js builds — env vars come from 1Password (`op run --env-file=apps/web/.env.tpl`) at runtime, not at build time.
+**IMPORTANT**: Always use `SKIP_ENV_VALIDATION=1` for local Next.js builds — env vars come from 1Password (`secrets-run run --env-file=apps/web/.env.tpl`) at runtime, not at build time.
 
 All scripts run from the workspace root unless noted. The root `package.json` delegates to workspace members via `bun run --filter=@fpp/<pkg>`.
 
@@ -210,7 +210,7 @@ make analytics-update-local              # Regenerate parquet files for /analyti
 
 ### Local env via 1Password (no Doppler)
 
-Each service has its own `.env.tpl` resolved at dev-script time by `op run --account tkrumm --env-file=.env.tpl --`. Only secrets that must actually match prod resolve from `op://vps/fpp/*` (e.g. `FPP_SERVER_SECRET`, `ANALYTICS_SECRET_TOKEN`) or `op://vps/mariadb/FPP_PASSWORD`; non-essentials (HyperDX, email) are hardcoded dummies. Vercel manages prod env directly.
+Each service has its own `.env.tpl` resolved at dev-script time by `secrets-run run --env-file=.env.tpl --` (a faithful `op run` drop-in: passthrough to `op` on the MacBook, encrypted-cache resolution on the mini). Only secrets that must actually match prod resolve from `op://vps/fpp/*` (e.g. `FPP_SERVER_SECRET`, `ANALYTICS_SECRET_TOKEN`) or `op://vps/mariadb/FPP_PASSWORD`; non-essentials (HyperDX, email) are hardcoded dummies. Vercel manages prod env directly.
 
 ### Local URLs
 
@@ -347,7 +347,7 @@ import { useRoomStore } from '../store/room.store';
 ### 🚨 Environment Variables
 - **Client vars**: Must be prefixed with `NEXT_PUBLIC_`
 - **Build command**: Always use `SKIP_ENV_VALIDATION=1 bun run build`
-- **Environment file**: 1Password via `op run --env-file=apps/web/.env.tpl` (see `apps/web/.env.tpl`). Production secrets live in Vercel and the VPS 1Password vault.
+- **Environment file**: 1Password via `secrets-run run --env-file=apps/web/.env.tpl` (see `apps/web/.env.tpl`). Production secrets live in Vercel and the VPS 1Password vault.
 
 ## ESLint & React 19 Linting
 
@@ -549,7 +549,7 @@ Users are anonymous. Each client generates a 21-character nanoid stored in local
 The app has an **action queue** in `useWebSocketRoom.ts` - actions sent while disconnected are queued and sent on reconnect.
 
 ### 5. Build Environment
-Local builds require `SKIP_ENV_VALIDATION=1` — environment variables are injected at runtime by `op run --env-file=apps/web/.env.tpl` (1Password).
+Local builds require `SKIP_ENV_VALIDATION=1` — environment variables are injected at runtime by `secrets-run run --env-file=apps/web/.env.tpl` (1Password).
 
 ## Error Handling Standards (OpenTelemetry → HyperDX)
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ GitHub Actions runs 17 jobs in parallel on every PR:
 4. `bun install`
 5. `bun run dev` (or `bun run dev:all` for the full stack with Logdy log UI on http://localhost:7723)
 
-Each service has its own `.env.tpl` (`apps/web/.env.tpl`, `apps/server/.env.tpl`, `fpp-analytics/.env.tpl`). The `dev` scripts wrap `op run --account tkrumm --env-file=.env.tpl -- ...` so 1Password references resolve to live values without ever writing them to disk.
+Each service has its own `.env.tpl` (`apps/web/.env.tpl`, `apps/server/.env.tpl`, `fpp-analytics/.env.tpl`). The `dev` scripts wrap `secrets-run run --env-file=.env.tpl -- ...` so 1Password references resolve to live values without ever writing them to disk.
 
 ### WebSocket server (standalone)
 
@@ -148,7 +148,7 @@ Each service has its own `.env.tpl` (`apps/web/.env.tpl`, `apps/server/.env.tpl`
 bun run --filter=@fpp/server dev   # port 7721
 ```
 
-Env vars are populated by `op run` from `apps/server/.env.tpl`. The only secret that resolves from 1Password is `FPP_SERVER_SECRET` (must match the Next.js side for flip-tracking callbacks); the rest are hardcoded local defaults.
+Env vars are populated by `secrets-run run` from `apps/server/.env.tpl`. The only secret that resolves from 1Password is `FPP_SERVER_SECRET` (must match the Next.js side for flip-tracking callbacks); the rest are hardcoded local defaults.
 
 ### Analytics service (standalone)
 

--- a/apps/server/.env.tpl
+++ b/apps/server/.env.tpl
@@ -1,5 +1,5 @@
 # FPP Server (Bun + Elysia WS) — local dev env via 1Password.
-# Resolved at runtime: `op run --account tkrumm --env-file=.env.tpl -- <cmd>`.
+# Resolved at runtime: `secrets-run run --env-file=.env.tpl -- <cmd>`.
 # Production env is injected by docker-compose on the VPS (see vps/apps/fpp).
 
 # --- Hardcoded local config ---

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.50",
   "private": true,
   "scripts": {
-    "dev": "../../scripts/kill-ports.sh 7721 && op run --account tkrumm --env-file=.env.tpl -- bun --watch src/index.ts",
+    "dev": "../../scripts/kill-ports.sh 7721 && secrets-run run --env-file=.env.tpl -- bun --watch src/index.ts",
     "build": "bun build src/index.ts --target bun --outdir ./dist",
     "start": "NODE_ENV=production bun dist/index.js",
     "test": "bun test",

--- a/apps/web/.env.tpl
+++ b/apps/web/.env.tpl
@@ -1,5 +1,5 @@
 # FPP Web (Next.js) — local dev env via 1Password.
-# Resolved at runtime: `op run --account tkrumm --env-file=.env.tpl -- <cmd>`.
+# Resolved at runtime: `secrets-run run --env-file=.env.tpl -- <cmd>`.
 # Production secrets live in Vercel — not here.
 
 # --- Hardcoded local config (matches Caddy hostnames) ---

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "../../scripts/kill-ports.sh 7720 && op run --account tkrumm --env-file=.env.tpl -- ./scripts/dev.sh",
+    "dev": "../../scripts/kill-ports.sh 7720 && secrets-run run --env-file=.env.tpl -- ./scripts/dev.sh",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/fpp-analytics/.env.tpl
+++ b/fpp-analytics/.env.tpl
@@ -1,5 +1,5 @@
 # FPP Analytics (FastAPI) — local dev env via 1Password.
-# Resolved at runtime: `op run --account tkrumm --env-file=.env.tpl -- <cmd>`.
+# Resolved at runtime: `secrets-run run --env-file=.env.tpl -- <cmd>`.
 # Production env is injected by docker-compose on the VPS (see vps/apps/fpp).
 #
 # Only ANALYTICS_SECRET_TOKEN actually matters for the local dev loop —


### PR DESCRIPTION
Completes the `op run` → `secrets-run run` migration started for analytics in #280.

## What

- `apps/web` + `apps/server` `dev` scripts now use `secrets-run run --env-file=.env.tpl`; the `--account tkrumm` flag is dropped (the shim supplies it).
- The three `.env.tpl` headers + the README / CLAUDE.md prose updated to match.

## The deferred tiering question resolves to a no-op

#280 left web/server alone because their `op://vps/fpp/*` and `op://vps/mariadb/FPP_PASSWORD` refs are prod-matching and "carry separate tiering questions".

That question only bites if a ref is **cached**. fpp is never run headless on the Mac mini, so no fpp ref is added to `headless.refs` and nothing is seeded — the prod-matching refs never enter the encrypted cache. No tiering call needed, no owner seed required.

## Behaviour

- **MacBook (op backend):** `secrets-run` is a literal passthrough to `op run --account tkrumm --env-file=<tpl> -- <cmd>` — dev is unchanged.
- **Mac mini (cache backend):** the refs are absent from the cache, so the scripts now fail fast with the missing-ref list instead of hanging forever on a biometric prompt no one is there to approve. Verified both templates parse and report exactly the right refs.

`make db-setup-local` stays on raw `op run` deliberately — it sources the cross-repo `../vps/.env.tpl` prod ref set and is human-only by nature.

## Validation

End-to-end `bun run dev` on the op backend can't be exercised from the mini; it's tracked as a checklist item for the MacBook (dotfiles-private `docs/step2-macbook-validation.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development and build instructions for the new environment-variable injection workflow.
  * Clarified service-specific environment templates and runtime secret resolution.
  * Documented which local values use secure secret resolution versus defaults.

* **Chores**
  * Updated development commands across services to use the revised environment configuration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->